### PR TITLE
Adjust OAuth prompt to avoid duplicate authorization URLs

### DIFF
--- a/secondary-droplet/tools/regen_token.py
+++ b/secondary-droplet/tools/regen_token.py
@@ -11,10 +11,16 @@ TOKEN="token.json"
 
 def main():
     flow = InstalledAppFlow.from_client_secrets_file(CLIENT_SECRET, SCOPES)
-    print("Abra este URL no seu browser:")
-    print(flow.authorization_url(access_type='offline', include_granted_scopes='true')[0])
-    creds = flow.run_local_server(port=8080, open_browser=False,
-        authorization_prompt_message="Depois de autorizar, será redirecionado para http://localhost:8080 (via túnel SSH).")
+    creds = flow.run_local_server(
+        port=8080,
+        open_browser=False,
+        authorization_prompt_message=(
+            "Abra este URL no seu browser e, depois de autorizar, "
+            "será redirecionado para http://localhost:8080 (via túnel SSH)."
+        ),
+        access_type="offline",
+        include_granted_scopes="true",
+    )
     with open(TOKEN, "w", encoding="utf-8") as f:
         f.write(creds.to_json())
     print(f"[OK] Token gravado em {TOKEN}")


### PR DESCRIPTION
## Summary
- rely on InstalledAppFlow.run_local_server to emit the authorization URL instead of printing it manually
- provide a Portuguese authorization prompt message that explains the redirection via the SSH tunnel
- request offline access and scope re-use directly through run_local_server so a single link is displayed

## Testing
- not run (requires Google OAuth credentials)


------
https://chatgpt.com/codex/tasks/task_e_68e144c42b88832297ea519590e2655a