### PR TITLE
Handle missing YouTube stream items

### DIFF
--- a/secondary-droplet/bin/yt_api_probe_once.py
+++ b/secondary-droplet/bin/yt_api_probe_once.py
@@ -16,7 +16,11 @@ def main():
         print("Sem broadcast live/testing visível pela API."); return 0
     sid = live["contentDetails"]["boundStreamId"]
     s = yt.liveStreams().list(part="id,status,cdn", id=sid).execute()
-    st = s["items"][0]; hs = st["status"].get("healthStatus", {})
+    stream_items = s.get("items", [])
+    if not stream_items:
+        print(f"Stream '{sid}' não encontrado pela API de liveStreams.")
+        return 1
+    st = stream_items[0]; hs = st["status"].get("healthStatus", {})
     print(json.dumps({
       "streamStatus": st["status"].get("streamStatus"),
       "healthStatus.status": hs.get("status"),

--- a/secondary-droplet/bin/yt_decider_daemon.py
+++ b/secondary-droplet/bin/yt_decider_daemon.py
@@ -30,7 +30,14 @@ def get_state(yt):
         return {"streamStatus":"?", "health":"?", "note":"sem broadcast"}
     sid = live["contentDetails"]["boundStreamId"]
     s = yt.liveStreams().list(part="id,status,cdn", id=sid).execute()
-    st = s["items"][0]
+    stream_items = s.get("items", [])
+    if not stream_items:
+        return {
+            "streamStatus": "?",
+            "health": "?",
+            "note": "stream não encontrado",
+        }
+    st = stream_items[0]
     hs = st["status"].get("healthStatus",{})
     return {
         "streamStatus": st["status"].get("streamStatus"),


### PR DESCRIPTION
## Summary
- return a safe fallback status from the decider when the bound live stream is missing
- surface a clear message from the API probe when the live stream lookup returns no items

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e14535371c832283a235fcc5310ed2