### PR TITLE
Add pytest coverage for decider logic

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,22 @@
+name: Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  pytest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r secondary-droplet/requirements.txt
+          pip install pytest
+      - name: Run pytest
+        run: pytest

--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -20,3 +20,15 @@ python3 /root/bwb-stream2yt/secondary-droplet/bin/yt_api_probe_once.py
 
 - Ver `journalctl -u yt-decider-daemon -f -l`
 - CSV de eventos (se existir) em `/root/yt_decider_log.csv`.
+
+## Testes
+
+Use `pytest` para validar rapidamente a lógica do decider antes de qualquer deploy:
+
+```bash
+cd /root/bwb-stream2yt
+python -m pip install --upgrade pip
+pip install -r secondary-droplet/requirements.txt
+pip install pytest
+pytest
+```

--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ scripts/
 3. Configurar **Droplet** (ver `DEPLOY.md`).
 4. Configurar **Windows** (ver `primary-windows/README.md`).
 
+## Testes automatizados
+
+Execute os testes antes de publicar alterações para garantir que o daemon decisor continua a tomar decisões corretas:
+
+```bash
+python -m pip install --upgrade pip
+pip install -r secondary-droplet/requirements.txt
+pip install pytest
+pytest
+```
+
+Os testes ficam em `secondary-droplet/tests/` e simulam diferentes estados da API do YouTube, sem necessidade de contactar serviços externos.
+
 ---
 
 ## Passo-a-passo (terminal)

--- a/secondary-droplet/tests/test_decider.py
+++ b/secondary-droplet/tests/test_decider.py
@@ -1,0 +1,145 @@
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+# Stub minimal google modules so yt_decider_daemon can be imported without external deps
+if "google" not in sys.modules:
+    google_module = types.ModuleType("google")
+    sys.modules["google"] = google_module
+else:
+    google_module = sys.modules["google"]
+
+google_oauth2 = types.ModuleType("google.oauth2")
+sys.modules["google.oauth2"] = google_oauth2
+google_module.oauth2 = google_oauth2
+
+google_credentials = types.ModuleType("google.oauth2.credentials")
+
+
+class _DummyCredentials:
+    @classmethod
+    def from_authorized_user_file(cls, *args, **kwargs):  # pragma: no cover - behaviour mocked in tests
+        return object()
+
+
+google_credentials.Credentials = _DummyCredentials
+sys.modules["google.oauth2.credentials"] = google_credentials
+google_oauth2.credentials = google_credentials
+
+googleapiclient = types.ModuleType("googleapiclient")
+sys.modules["googleapiclient"] = googleapiclient
+
+discovery_module = types.ModuleType("googleapiclient.discovery")
+
+
+def _dummy_build(*args, **kwargs):  # pragma: no cover - replaced in tests
+    raise AssertionError("build() should be patched in tests")
+
+
+discovery_module.build = _dummy_build
+googleapiclient.discovery = discovery_module
+sys.modules["googleapiclient.discovery"] = discovery_module
+
+BIN_PATH = Path(__file__).resolve().parents[1] / "bin"
+if str(BIN_PATH) not in sys.path:
+    sys.path.insert(0, str(BIN_PATH))
+
+import yt_decider_daemon as decider
+
+
+class StopLoop(Exception):
+    """Helper exception to interrupt the infinite loop."""
+
+
+def run_single_cycle(monkeypatch, *, state, hour, fallback_active):
+    """Execute one main loop iteration with controlled environment."""
+
+    monkeypatch.setattr(decider, "build_api", lambda: object())
+    monkeypatch.setattr(decider, "get_state", lambda _api: state)
+    monkeypatch.setattr(decider, "local_hour", lambda: hour)
+    monkeypatch.setattr(decider, "is_active", lambda _unit: fallback_active)
+
+    start_calls = []
+    stop_calls = []
+    monkeypatch.setattr(decider, "start_fallback", lambda: start_calls.append(True))
+    monkeypatch.setattr(decider, "stop_fallback", lambda: stop_calls.append(True))
+
+    rows = []
+    monkeypatch.setattr(decider, "csv_log", lambda row: rows.append(row))
+
+    def _sleep(_seconds):
+        raise StopLoop()
+
+    monkeypatch.setattr(decider.time, "sleep", _sleep)
+
+    with pytest.raises(StopLoop):
+        decider.main()
+
+    return {
+        "rows": rows,
+        "start_calls": len(start_calls),
+        "stop_calls": len(stop_calls),
+    }
+
+
+def test_daytime_primary_ok_stops_secondary(monkeypatch):
+    result = run_single_cycle(
+        monkeypatch,
+        state={"streamStatus": "active", "health": "good", "note": ""},
+        hour=10,
+        fallback_active=True,
+    )
+
+    assert result["stop_calls"] == 1
+    assert result["start_calls"] == 0
+    assert result["rows"]
+    action_row = result["rows"][0]
+    assert action_row[4] == "STOP secondary"
+    assert action_row[5] == "day primary OK"
+
+
+def test_daytime_without_primary_starts_secondary(monkeypatch):
+    result = run_single_cycle(
+        monkeypatch,
+        state={"streamStatus": "?", "health": "bad", "note": "sem primário"},
+        hour=11,
+        fallback_active=False,
+    )
+
+    assert result["start_calls"] == 1
+    assert result["stop_calls"] == 0
+    action_row = result["rows"][0]
+    assert action_row[4] == "START secondary"
+    assert action_row[5] == "day but no primary"
+
+
+def test_night_without_primary_starts_secondary(monkeypatch):
+    result = run_single_cycle(
+        monkeypatch,
+        state={"streamStatus": "inactive", "health": "noData", "note": ""},
+        hour=2,
+        fallback_active=False,
+    )
+
+    assert result["start_calls"] == 1
+    assert result["stop_calls"] == 0
+    action_row = result["rows"][0]
+    assert action_row[4] == "START secondary"
+    assert action_row[5] == "night + no primary"
+
+
+def test_night_with_healthy_primary_keeps_state(monkeypatch):
+    result = run_single_cycle(
+        monkeypatch,
+        state={"streamStatus": "active", "health": "good", "note": ""},
+        hour=22,
+        fallback_active=True,
+    )
+
+    assert result["start_calls"] == 0
+    assert result["stop_calls"] == 0
+    action_row = result["rows"][0]
+    assert action_row[4] == "KEEP"
+    assert action_row[5] == ""


### PR DESCRIPTION
## Summary
- add pytest-based coverage for yt_decider_daemon scenarios using mocks of the YouTube API and systemctl helpers
- document how to run the new pytest suite in README.md and OPERATIONS.md
- configure a GitHub Actions workflow that installs dependencies and runs pytest on every push and pull request

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e146b633a083229ec2f29f56ef67f6