### PR TITLE
Ensure deploy script creates remote directories

### DIFF
--- a/scripts/deploy_to_droplet.sh
+++ b/scripts/deploy_to_droplet.sh
@@ -6,6 +6,8 @@ DEST_USER="${DEST_USER:-root}"
 DEST_IP="${DEST_IP:-104.248.134.44}"
 DEST_DIR="${DEST_DIR:-/root/bwb-stream2yt}"
 
+ssh -o StrictHostKeyChecking=accept-new "${DEST_USER}@${DEST_IP}" "mkdir -p '${DEST_DIR}/secondary-droplet' '${DEST_DIR}/scripts'"
+
 rsync -avz --delete \
   --exclude '*.env' --exclude 'token.json' --exclude 'client_secret.json' \
   "$(dirname "$0")/../secondary-droplet/" "${DEST_USER}@${DEST_IP}:${DEST_DIR}/secondary-droplet/"


### PR DESCRIPTION
## Summary
- ensure the deploy script creates remote secondary-droplet and scripts directories before syncing files

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e14f4fae3c83228bb3bfec958662f5