### PR TITLE
Update YouTube fallback backup URL format

### DIFF
--- a/secondary-droplet/bin/youtube_fallback.sh
+++ b/secondary-droplet/bin/youtube_fallback.sh
@@ -10,7 +10,7 @@ if [ -z "${YT_KEY:-}" ]; then
   echo "[youtube_fallback] ERRO: YT_KEY vazio (env: $ENV_FILE)."; exit 1
 fi
 
-: "${YT_URL_BACKUP:=rtmps://b.rtmps.youtube.com/live2?backup=1/${YT_KEY}}"
+: "${YT_URL_BACKUP:=rtmps://b.rtmps.youtube.com/live2/${YT_KEY}?backup=1}"
 
 : "${FALLBACK_IMG:=/usr/local/share/youtube-fallback/SignalLost.jpg}"
 : "${FALLBACK_WIDTH:=1280}"


### PR DESCRIPTION
## Summary
- correct the YouTube backup stream URL to place the key before the backup query parameter

## Testing
- PATH="/tmp/bin:$PATH" YT_KEY=TESTKEY /usr/local/bin/youtube_fallback.sh

------
https://chatgpt.com/codex/tasks/task_e_68e15464107c8322a75542b78b1332ff