### PR TITLE
Add shared logging for streaming services

### DIFF
--- a/docs/OPERATIONS_CHECKLIST.md
+++ b/docs/OPERATIONS_CHECKLIST.md
@@ -4,6 +4,12 @@
 - `systemctl status yt-decider-daemon youtube-fallback`
 - `journalctl -u yt-decider-daemon -n 60 -l --no-pager`
 - `tail -n 50 /root/yt_decider_log.csv`
+- `tail -n 100 /root/bwb_services.log` (event log para primário, fallback e daemon)
+
+### Log centralizado (`/root/bwb_services.log`)
+- Consultar com `less +F /root/bwb_services.log` para acompanhar eventos em tempo real.
+- Rodar manualmente se necessário: `logrotate -f /etc/logrotate.d/bwb-services` (criar entrada caso não exista).
+- Garantir que o ficheiro não cresça indefinidamente (>200 MB): arquivar/comprimir periodicamente ou integrar com logrotate.
 
 ## If backup URL reuses `${YT_KEY}` literal
 - Confirm `/etc/youtube-fallback.env` contains only `YT_KEY="..."


### PR DESCRIPTION
## Summary
- add a shared log_event helper for the Windows primary sender and capture ffmpeg lifecycle events
- redirect the fallback sender output to /root/bwb_services.log and log start/stop plus ffmpeg exit codes
- extend the yt_decider daemon and operations checklist with references to the central service log

## Testing
- python -m compileall primary-windows/src/stream_to_youtube.py secondary-droplet/bin/yt_decider_daemon.py

------
https://chatgpt.com/codex/tasks/task_e_68e17c8d457483229ed6a71f360a70ae