### PR TITLE
Improve youtube fallback signal logging and ffmpeg verbosity control

### DIFF
--- a/secondary-droplet/bin/youtube_fallback.sh
+++ b/secondary-droplet/bin/youtube_fallback.sh
@@ -40,14 +40,30 @@ fi
 : "${FALLBACK_GOP:=60}"
 : "${FALLBACK_KEYINT_MIN:=60}"
 : "${FALLBACK_DELAY_SEC:=3.0}"
+: "${FALLBACK_LOGLEVEL:=warning}"
 : "${FALLBACK_FONT:=/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf}"
 : "${FALLBACK_SCROLL_TEXT:=BEACHCAM | CABO LEDO | ANGOLA}"
 : "${FALLBACK_STATIC_TEXT:=VOLTAREMOS DENTRO DE MOMENTOS}"
 
 echo "[youtube_fallback] Envio contínuo → ${YT_URL_BACKUP}"
-echo "[youtube_fallback] ${FALLBACK_WIDTH}x${FALLBACK_HEIGHT}@${FALLBACK_FPS} | V=${FALLBACK_VBITRATE}/${FALLBACK_MAXRATE}/${FALLBACK_BUFSIZE} | A=${FALLBACK_ABITRATE}@${FALLBACK_AR} | Delay=${FALLBACK_DELAY_SEC}s | GOP=${FALLBACK_GOP}"
+echo "[youtube_fallback] ${FALLBACK_WIDTH}x${FALLBACK_HEIGHT}@${FALLBACK_FPS} | V=${FALLBACK_VBITRATE}/${FALLBACK_MAXRATE}/${FALLBACK_BUFSIZE} | A=${FALLBACK_ABITRATE}@${FALLBACK_AR} | Delay=${FALLBACK_DELAY_SEC}s | GOP=${FALLBACK_GOP} | LogLevel=${FALLBACK_LOGLEVEL}"
 
-if ffmpeg -progress /run/youtube-fallback.progress -hide_banner -loglevel warning -nostats \
+handle_signal() {
+  local sig="$1"
+  log_line "Recebido SIG${sig}, encerrando"
+  trap - "$sig"
+  kill -s "$sig" "$$"
+}
+
+trap 'handle_signal HUP' HUP
+trap 'handle_signal INT' INT
+trap 'handle_signal QUIT' QUIT
+trap 'handle_signal PIPE' PIPE
+trap 'handle_signal TERM' TERM
+
+log_line "Iniciando ffmpeg (loglevel=${FALLBACK_LOGLEVEL})"
+
+if ffmpeg -progress /run/youtube-fallback.progress -hide_banner -loglevel "${FALLBACK_LOGLEVEL}" -nostats \
   -re -stream_loop -1 -framerate "${FALLBACK_FPS}" -i "${FALLBACK_IMG}" \
   -f lavfi -i "anullsrc=channel_layout=stereo:sample_rate=${FALLBACK_AR}" \
   -filter_complex "[0:v]scale=${FALLBACK_WIDTH}:${FALLBACK_HEIGHT}:force_original_aspect_ratio=decrease,pad=${FALLBACK_WIDTH}:${FALLBACK_HEIGHT}:(ow-iw)/2:(oh-ih)/2:color=black,format=yuv420p,setpts=PTS+${FALLBACK_DELAY_SEC}/TB,drawtext=fontfile=${FALLBACK_FONT}:text='${FALLBACK_SCROLL_TEXT}':fontsize=36:fontcolor=white:shadowcolor=black@0.85:shadowx=2:shadowy=2:x=w-mod(t*30*8\,w+text_w):y=H-60,drawtext=fontfile=${FALLBACK_FONT}:text='${FALLBACK_STATIC_TEXT}':fontsize=28:fontcolor=white:shadowcolor=black@0.85:shadowx=2:shadowy=2:x=(w-text_w)/2:y=60[vb];[1:a]asetpts=PTS+${FALLBACK_DELAY_SEC}/TB[ab]" \
@@ -62,5 +78,18 @@ else
   status=$?
 fi
 
-log_line "ffmpeg terminou (exit ${status})"
+if [ "$status" -ge 128 ]; then
+  signal=$((status - 128))
+  if [ "$signal" -gt 0 ] 2>/dev/null; then
+    if name=$(kill -l "$signal" 2>/dev/null); then
+      log_line "ffmpeg terminou por SIG${name} (exit ${status})"
+    else
+      log_line "ffmpeg terminou por sinal ${signal} (exit ${status})"
+    fi
+  else
+    log_line "ffmpeg terminou (exit ${status})"
+  fi
+else
+  log_line "ffmpeg terminou (exit ${status})"
+fi
 exit ${status}


### PR DESCRIPTION
## Summary
- add configurable FALLBACK_LOGLEVEL and emit startup logging for ffmpeg runs
- translate ffmpeg exit statuses into signal names for clearer shutdown messages
- log incoming termination signals and re-raise them to preserve default behavior

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e18d9d94d48322b21f61d054588400