### PR TITLE
docs: atualizar referências para log centralizado

### DIFF
--- a/OPERATIONS.md
+++ b/OPERATIONS.md
@@ -19,7 +19,7 @@ python3 /root/bwb-stream2yt/secondary-droplet/bin/yt_api_probe_once.py
 ## Decider (se usado)
 
 - Ver `journalctl -u yt-decider-daemon -f -l`
-- CSV de eventos (se existir) em `/root/yt_decider_log.csv`.
+- Consultar o histórico consolidado em `/root/bwb_services.log` (contém decisões do decider, eventos do fallback e notas do primário).
 
 ## Testes
 

--- a/docs/CODING_GUIDE.md
+++ b/docs/CODING_GUIDE.md
@@ -11,7 +11,7 @@
   - 720p30 backup (Droplet) with `-b:v 1500k`, `-g 60`, scroll/static texts overlay to indicate fallback.
 
 ## Logs
-- Human-oriented console logs + CSV (`/root/yt_decider_log.csv`) with minimal noise (only relevant transitions).
+- Human-oriented console logs + ficheiro unificado (`/root/bwb_services.log`) com transições relevantes do decider e estado dos serviços.
 
 ## Windows build
 - Build with **PyInstaller 6.10** (or compatible) targeting Python 3.11.

--- a/docs/OPERATIONS_CHECKLIST.md
+++ b/docs/OPERATIONS_CHECKLIST.md
@@ -3,11 +3,11 @@
 ## Daily sanity
 - `systemctl status yt-decider-daemon youtube-fallback`
 - `journalctl -u yt-decider-daemon -n 60 -l --no-pager`
-- `tail -n 50 /root/yt_decider_log.csv`
 - `tail -n 100 /root/bwb_services.log` (event log para primário, fallback e daemon)
 
 ### Log centralizado (`/root/bwb_services.log`)
 - Consultar com `less +F /root/bwb_services.log` para acompanhar eventos em tempo real.
+- O ficheiro inclui todos os eventos anteriormente registados no CSV `yt_decider_log`, além dos estados dos serviços primário e fallback.
 - Rodar manualmente se necessário: `logrotate -f /etc/logrotate.d/bwb-services` (criar entrada caso não exista).
 - Garantir que o ficheiro não cresça indefinidamente (>200 MB): arquivar/comprimir periodicamente ou integrar com logrotate.
 

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -23,6 +23,6 @@ This repository contains **two logical modules**:
 - Fallback sender: `/usr/local/bin/youtube_fallback.sh`
 - Fallback env: `/etc/youtube-fallback.env`
 - Unit files: `/etc/systemd/system/*.service`
-- Logs (csv): `/root/yt_decider_log.csv`
+- Log centralizado: `/root/bwb_services.log`
 
 > **Stream Key**: manter apenas em ficheiros `.env` / secrets seguros; nunca o commits no repositório público.

--- a/docs/REGRAS_URL_SECUNDARIA.md
+++ b/docs/REGRAS_URL_SECUNDARIA.md
@@ -64,7 +64,9 @@ Os serviços principais do Droplet:
 |----------|------------|----------------|
 | `yt-decider-daemon.service` | Monitoriza a API do YouTube e comanda o fallback | `active (running)` |
 | `youtube-fallback.service` | Envia o sinal de contingência para o YouTube | `active (running)` |
-| `/root/yt_decider_log.csv` | Log cronológico de decisões automáticas | Atualizado continuamente |
+| `/root/bwb_services.log` | Log centralizado de decisões automáticas e eventos dos serviços | Atualizado continuamente |
+
+> O antigo CSV `yt_decider_log` foi fundido neste registo único; todas as consultas operacionais devem usar **exclusivamente** `/root/bwb_services.log`.
 
 **Reação automática a falhas:**
 - `Restart=always` no systemd
@@ -82,7 +84,7 @@ Os serviços principais do Droplet:
 | `/usr/local/bin/yt_decider_daemon.py` | Monitor do estado da stream |
 | `/etc/systemd/system/youtube-fallback.service` | Unit de arranque e recuperação |
 | `/etc/systemd/system/yt-decider-daemon.service` | Unit do monitor principal |
-| `/root/yt_decider_log.csv` | Registo contínuo de decisões |
+| `/root/bwb_services.log` | Registo unificado de decisões e eventos dos serviços |
 
 ---
 
@@ -133,6 +135,6 @@ systemctl status yt-decider-daemon youtube-fallback --no-pager
 journalctl -u yt-decider-daemon -n 40 -l --no-pager
 journalctl -u youtube-fallback -n 40 -l --no-pager
 
-# CSV de decisões
-tail -n 20 /root/yt_decider_log.csv
+# Log centralizado
+tail -n 100 /root/bwb_services.log
 ```


### PR DESCRIPTION
## Summary
- update operations checklist to focus on the unified /root/bwb_services.log and document its expanded coverage
- refresh operations, project overview, and coding guide docs to treat the central log as the single source of truth
- align secondary URL playbook with the new logging flow, replacing csv references with consolidated log guidance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1922cde2c8322826067db2b274b62