### PR TITLE
Add logrotate config for bwb services log

### DIFF
--- a/deploy/deploy_config.json
+++ b/deploy/deploy_config.json
@@ -34,6 +34,11 @@
       "remote": "/etc/youtube-fallback.env",
       "mode": "644",
       "if_missing_only": true
+    },
+    {
+      "local": "secondary-droplet/config/logrotate/bwb-services",
+      "remote": "/etc/logrotate.d/bwb-services",
+      "mode": "644"
     }
   ]
 }

--- a/docs/OPERATIONS_CHECKLIST.md
+++ b/docs/OPERATIONS_CHECKLIST.md
@@ -8,8 +8,8 @@
 ### Log centralizado (`/root/bwb_services.log`)
 - Consultar com `less +F /root/bwb_services.log` para acompanhar eventos em tempo real.
 - O ficheiro inclui todos os eventos anteriormente registados no CSV `yt_decider_log`, além dos estados dos serviços primário e fallback.
-- Rodar manualmente se necessário: `logrotate -f /etc/logrotate.d/bwb-services` (criar entrada caso não exista).
-- Garantir que o ficheiro não cresça indefinidamente (>200 MB): arquivar/comprimir periodicamente ou integrar com logrotate.
+- A rotação de 24h é automática via logrotate (mantém apenas eventos das últimas 24 horas).
+- Rodar manualmente se necessário: `logrotate -f /etc/logrotate.d/bwb-services`.
 
 ## If backup URL reuses `${YT_KEY}` literal
 - Confirm `/etc/youtube-fallback.env` contains only `YT_KEY="..."

--- a/secondary-droplet/config/logrotate/bwb-services
+++ b/secondary-droplet/config/logrotate/bwb-services
@@ -1,0 +1,8 @@
+/root/bwb_services.log {
+    daily
+    copytruncate
+    rotate 0
+    maxage 1
+    missingok
+    notifempty
+}


### PR DESCRIPTION
## Summary
- add a logrotate definition for /root/bwb_services.log that keeps only 24 hours of entries
- sync the logrotate configuration via deploy_config.json
- document the automated daily rotation in the operations checklist

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e193dd40cc83229b77fa0f5afcdb27