### PR TITLE
Atualiza ciclo de decisão da URL secundária para 20s

### DIFF
--- a/docs/REGRAS_URL_SECUNDARIA.md
+++ b/docs/REGRAS_URL_SECUNDARIA.md
@@ -97,10 +97,14 @@ flowchart TD
     B -->|Não| D{Secundário ativo?}
     D -->|Não| E[Iniciar youtube-fallback.service]
     D -->|Sim| F[Manter sinal de contingência]
-    E --> G[Reavaliar a cada 30s]
+    E --> G[Reavaliar a cada 20s]
     F --> G
     G --> B
 ```
+
+> ⏱️ O `yt_decider_daemon.py` executa ciclos de decisão a cada **20 segundos**,
+> garantindo que a avaliação do estado da stream se mantém alinhada com o
+> comportamento real do serviço (`CYCLE = 20`).
 
 ---
 


### PR DESCRIPTION
## Summary
- atualiza o fluxograma da documentação para refletir reavaliações a cada 20 segundos
- acrescenta nota reforçando o ciclo de decisão de 20 segundos conforme yt_decider_daemon.py

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e195bb92b48322afddce43fb4ca582