### PR TITLE
Add release workflow for Windows release builds

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,62 @@
+name: Release build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tooling
+        run: |
+          python -m pip install --upgrade pip wheel
+          python -m pip install pyinstaller==6.10
+
+      - name: Build executable
+        run: |
+          python -m PyInstaller --clean --onefile primary-windows/src/stream_to_youtube.py
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: primary-windows-exe
+          path: dist/stream_to_youtube.exe
+
+  release:
+    needs: build
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: primary-windows-exe
+          path: dist
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: release-${{ github.run_number }}
+          name: Release ${{ github.run_number }}
+          generate_release_notes: true
+          files: dist/**
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- add release-build workflow triggered on push, pull request, and manual runs for main branch
- build Windows executable via PyInstaller and upload artifact
- publish a GitHub Release from main branch runs with the generated artifact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1a07168b08322accf7d9f961210b2