### PR TITLE
Add spacing before is_active

### DIFF
--- a/secondary-droplet/bin/yt_decider_daemon.py
+++ b/secondary-droplet/bin/yt_decider_daemon.py
@@ -96,6 +96,8 @@ def get_state(yt):
         "health": hs.get("status", "?"),
         "note": "",
     }
+
+
 def is_active(unit):
     return (
         run(["systemctl", "is-active", unit], capture_output=True, text=True).returncode


### PR DESCRIPTION
## Summary
- insert two blank lines between get_state and is_active in yt_decider_daemon.py

## Testing
- python -m black secondary-droplet/bin/yt_decider_daemon.py
- python -m flake8 *(fails: ModuleNotFoundError: No module named 'flake8')*

------
https://chatgpt.com/codex/tasks/task_e_68e1a70dcee08322905c505916d5a1b1