### PR TITLE
Manage youtube-fallback env during post deploy

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -38,9 +38,10 @@ systemctl enable --now youtube-fallback.service
 
 ```
 # YT_KEY (backup)
-printf 'YT_KEY="SUA_CHAVE_AQUI"
-' > /etc/youtube-fallback.env
-chmod 640 /etc/youtube-fallback.env && chown root:root /etc/youtube-fallback.env
+# post_deploy.sh irá regenerar o ficheiro preservando a chave e restaurando os defaults comentados.
+printf 'YT_KEY="SUA_CHAVE_AQUI"\n' > /etc/youtube-fallback.env
+chown root:root /etc/youtube-fallback.env
+chmod 644 /etc/youtube-fallback.env
 systemctl restart youtube-fallback
 
 # OAuth token para YouTube Data API

--- a/deploy/deploy_config.json
+++ b/deploy/deploy_config.json
@@ -3,6 +3,7 @@
   "ssh_user": "root",
   "ssh_key": "~/.ssh/id_rsa",
   "remote_prefix": "/",
+  "post_deploy_notes": "post_deploy.sh reescreve /etc/youtube-fallback.env preservando YT_KEY e restaurando os padrões comentados.",
   "sync_map": [
     {
       "local": "secondary-droplet/bin/yt_decider_daemon.py",

--- a/docs/OPERATIONS_CHECKLIST.md
+++ b/docs/OPERATIONS_CHECKLIST.md
@@ -13,7 +13,7 @@
 
 ## If backup URL reuses `${YT_KEY}` literal
 - Confirm `/usr/local/config/youtube-fallback.defaults` matches the expected slate defaults (managed via deploy).
-- Confirm `/etc/youtube-fallback.env` contains only `YT_KEY="..."`.
+- Confirm `/etc/youtube-fallback.env` preserva `YT_KEY="..."` e mostra as linhas comentadas com os defaults atuais.
 - Ensure **no** `YT_URL_BACKUP` line remains stale.
 - `systemctl daemon-reload && systemctl restart youtube-fallback`
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -20,7 +20,7 @@ Two-module setup:
 
 ### Secondary (Droplet)
 1. Defaults ship in `/usr/local/config/youtube-fallback.defaults`; adjust there if the standard slate settings need to change.
-2. Put stream key in `/etc/youtube-fallback.env` (`YT_KEY="..."`). Use this file only for secrets or conscious overrides.
+2. Put stream key in `/etc/youtube-fallback.env` (`YT_KEY="..."`). O `post_deploy.sh` reescreve este ficheiro preservando `YT_KEY` e restaurando as linhas comentadas com os defaults para referência — use-o apenas para segredos ou overrides conscientes.
 2. Install units & scripts from `secondary-droplet/` and run:
   ```bash
   sudo systemctl daemon-reload

--- a/docs/REGRAS_URL_SECUNDARIA.md
+++ b/docs/REGRAS_URL_SECUNDARIA.md
@@ -81,7 +81,7 @@ Os serviços principais do Droplet:
 |----------|--------|
 | `/usr/local/bin/youtube_fallback.sh` | Script principal do sinal secundário |
 | `/usr/local/config/youtube-fallback.defaults` | Defaults do slate (resolução, bitrates, textos) |
-| `/etc/youtube-fallback.env` | Overrides conscientes (`YT_KEY`, ajustes específicos) |
+| `/etc/youtube-fallback.env` | Overrides conscientes (`YT_KEY`, ajustes específicos) — reescrito pelo `post_deploy.sh` preservando a chave |
 | `/usr/local/bin/yt_decider_daemon.py` | Monitor do estado da stream |
 | `/etc/systemd/system/youtube-fallback.service` | Unit de arranque e recuperação |
 | `/etc/systemd/system/yt-decider-daemon.service` | Unit do monitor principal |
@@ -124,9 +124,9 @@ sudo systemctl status yt-decider-daemon youtube-fallback --no-pager
 
 ## 🔹 9. Nota sobre Chaves e Segurança
 
-- Utilize a variável `YT_KEY` definida em `/etc/youtube-fallback.env` (ver `secondary-droplet/config/youtube-fallback.env.example`) para configurar a chave do YouTube sem expor valores reais.
+- Utilize a variável `YT_KEY` definida em `/etc/youtube-fallback.env` (ver `secondary-droplet/config/youtube-fallback.env.example`) para configurar a chave do YouTube sem expor valores reais. O `post_deploy.sh` garante que o ficheiro mantém `YT_KEY` e repõe as linhas comentadas com os defaults atuais.
 - Não incluir a chave em ficheiros públicos ou mensagens de suporte.
-- O ficheiro `.env` deve ter permissões `600` e proprietário `root`, garantindo acesso restrito.
+- O ficheiro `.env` é recriado com permissões `0644` e proprietário `root`; ajuste as permissões apenas se políticas locais exigirem algo mais restritivo.
 
 ---
 

--- a/scripts/post_deploy.sh
+++ b/scripts/post_deploy.sh
@@ -10,9 +10,46 @@ pip3 install -r requirements.txt
 install -m 755 -o root -g root bin/youtube_fallback.sh /usr/local/bin/youtube_fallback.sh
 install -m 644 -o root -g root systemd/youtube-fallback.service /etc/systemd/system/youtube-fallback.service
 
+ENV_FILE="/etc/youtube-fallback.env"
+DEFAULTS_FILE="config/youtube-fallback.defaults"
+
+existing_key=""
+if [[ -f "${ENV_FILE}" ]]; then
+    while IFS= read -r line; do
+        case "${line}" in
+            YT_KEY=*)
+                existing_key="${line#YT_KEY=}"
+                ;;
+        esac
+    done < "${ENV_FILE}"
+fi
+
+if [[ -z "${existing_key}" ]]; then
+    existing_key='""'
+fi
+
+tmp_env="$(mktemp)"
+trap 'rm -f "'"${tmp_env}"'"' EXIT
+{
+    echo "# /etc/youtube-fallback.env (managed by post_deploy.sh)"
+    echo "# Defaults live in /usr/local/config/youtube-fallback.defaults. Override only what you need here."
+    echo "YT_KEY=${existing_key}"
+    echo
+    echo "# Default parameters for reference:"
+    while IFS= read -r default_line; do
+        [[ -z "${default_line}" ]] && continue
+        [[ "${default_line}" =~ ^# ]] && continue
+        echo "#${default_line}"
+    done < "${DEFAULTS_FILE}"
+} > "${tmp_env}"
+
+install -m 644 -o root -g root "${tmp_env}" "${ENV_FILE}"
+rm -f "${tmp_env}"
+trap - EXIT
+
 systemctl daemon-reload
 systemctl enable --now youtube-fallback.service
 systemctl restart youtube-fallback.service || true
 
-# Não tocamos em /etc/youtube-fallback.env nem em token.json (segredos)
-echo "[post_deploy] youtube-fallback atualizado."
+# Mantemos token.json intacto; /etc/youtube-fallback.env é regenerado preservando YT_KEY.
+echo "[post_deploy] youtube-fallback atualizado e env sincronizado."


### PR DESCRIPTION
## Summary
- regenerate `/etc/youtube-fallback.env` from managed defaults while preserving `YT_KEY` during `post_deploy.sh`
- ensure the env file is installed with `root:root` ownership and `0644` mode
- document the managed behaviour across deploy config and operator docs

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1b241aef883229840a7d82d17d1a3