### PR TITLE
Handle YouTube stream error and revoked health states

### DIFF
--- a/secondary-droplet/bin/yt_decider_daemon.py
+++ b/secondary-droplet/bin/yt_decider_daemon.py
@@ -192,11 +192,19 @@ def main():
         detail = state["note"] or ""
 
         primary_ok = stream_status == "active" and health in ("good", "ok")
-        primary_bad = stream_status in ("inactive", "?") or health in (
+        primary_bad = stream_status in (
+            "inactive",
+            "?",
+            "error",
+        ) or health in (
             "noData",
             "?",
             "bad",
+            "revoked",
         )
+        # Discovery doc (https://developers.google.com/youtube/v3/live/docs/liveStream#status)
+        # notes that ``error`` and ``revoked`` indicate primary ingest failure, so treat them
+        # like other fatal states even if the stream was previously active.
 
         if primary_ok:
             context.primary_ok_streak += 1

--- a/secondary-droplet/tests/test_decider.py
+++ b/secondary-droplet/tests/test_decider.py
@@ -168,6 +168,42 @@ def test_daytime_without_primary_starts_secondary(monkeypatch):
     assert fields[5] == "day but no primary"
 
 
+def test_daytime_stream_error_starts_secondary(monkeypatch):
+    scenarios = [
+        {
+            "state": {"streamStatus": "error", "health": "bad", "note": ""},
+            "hour": 10,
+            "fallback_active": False,
+        }
+        for _ in range(decider.START_BAD_STREAK)
+    ]
+
+    result = run_cycles(monkeypatch, scenarios)
+
+    assert result["start_calls"] == 1
+    fields = _extract_decision_fields(result)
+    assert fields[4] == "START secondary"
+    assert fields[5] == "day but no primary"
+
+
+def test_daytime_health_revoked_starts_secondary(monkeypatch):
+    scenarios = [
+        {
+            "state": {"streamStatus": "active", "health": "revoked", "note": ""},
+            "hour": 10,
+            "fallback_active": False,
+        }
+        for _ in range(decider.START_BAD_STREAK)
+    ]
+
+    result = run_cycles(monkeypatch, scenarios)
+
+    assert result["start_calls"] == 1
+    fields = _extract_decision_fields(result)
+    assert fields[4] == "START secondary"
+    assert fields[5] == "day but no primary"
+
+
 def test_night_without_primary_starts_secondary(monkeypatch):
     result = run_cycles(
         monkeypatch,


### PR DESCRIPTION
## Summary
- treat YouTube `streamStatus="error"` and `health="revoked"` as fatal primary ingest states per the discovery doc so the decider falls back correctly
- extend the decider test suite to cover the new failure scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e1b8ae854c83229fb71bfccc0a0e30