### PR TITLE
Make Windows log path configurable

### DIFF
--- a/primary-windows/README.md
+++ b/primary-windows/README.md
@@ -21,6 +21,9 @@ Ferramenta oficial para enviar o feed (RTSP/DirectShow) para a URL **primária**
 - `YT_DAY_START_HOUR`, `YT_DAY_END_HOUR` e `YT_TZ_OFFSET_HOURS` controlam a janela de transmissão.
 - `YT_INPUT_ARGS` / `YT_OUTPUT_ARGS` permitem ajustar os argumentos do ffmpeg.
 - `FFMPEG` aponta para o executável do ffmpeg (por omissão `C:\bwb\ffmpeg\bin\ffmpeg.exe`).
+- `BWB_LOG_FILE` define onde o log compartilhado é gravado. Por padrão usamos
+  `logs/bwb_services.log` ao lado do script/executável, criando a pasta
+  automaticamente no Windows.
 
 ## Build (one-file) com PyInstaller
 


### PR DESCRIPTION
## Summary
- allow configuring the shared log path via the `BWB_LOG_FILE` environment variable and default it beside the executable
- ensure the log directory is created before writing and failures remain non-fatal
- document the log location for operators in the Windows README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1b987fb0c832290471d8e6e50573b