### PR TITLE
Add Windows sender YouTube output override

### DIFF
--- a/primary-windows/src/.env
+++ b/primary-windows/src/.env
@@ -1,0 +1,1 @@
+YT_OUTPUT_ARGS=-vf scale=1280:720:flags=bicubic,format=yuv420p -r 30 -c:v libx264 -preset veryfast -profile:v high -level 4.1 -b:v 3200k -maxrate 3500k -bufsize 6000k -g 60 -sc_threshold 0 -pix_fmt yuv420p -filter:a "aresample=async=1:first_pts=0, aformat=sample_fmts=fltp:sample_rates=44100:channel_layouts=stereo" -c:a aac -b:a 128k -ar 44100 -ac 2


### PR DESCRIPTION
## Summary
- add a Windows sender `.env` file that sets `YT_OUTPUT_ARGS` for a 720p/30fps stream configuration

## Testing
- not run (configuration-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e1c345031883229c47a3fe4acd538d