### PR TITLE
Atualiza documentação de instalação do primary-windows

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,16 +10,12 @@ Two-module setup:
 
 ### Primary (Windows)
 
-- 📘 Consulte o [guia completo de instalação no Windows](primary-windows-instalacao.md) para um passo a passo detalhado.
+- 📘 Consulte o [guia completo de instalação no Windows](primary-windows-instalacao.md#2-executável-distribuído) para seguir o fluxo recomendado com o executável distribuído.
 
-1. Install Python 3.11 and PyInstaller.
-2. Configure the stream credentials via environment variables or a `.env` file:
-   - `YT_URL` — URL completo `rtmps://a.rtmps.youtube.com/live2/<KEY>`.
-   - `YT_KEY` — apenas a chave; o URL é construído automaticamente.
-   Copie `primary-windows/src/.env.example` para `.env` (no mesmo diretório) ou defina as variáveis antes de executar.
-3. Ajuste `primary-windows/src/stream_to_youtube.py` apenas se precisar alterar o dispositivo de entrada.
-4. Build: `py -3.11 -m pip install -U pyinstaller==6.10` then `py -3.11 -m PyInstaller --clean --onefile primary-windows/src/stream_to_youtube.py`.
-5. Run the generated `dist/stream_to_youtube.exe`, garantindo que `YT_URL` ou `YT_KEY` estejam presentes no ambiente.
+1. Posicione `stream_to_youtube.exe` em `C:\bwb\apps\YouTube\` e mantenha o FFmpeg em `C:\bwb\ffmpeg\bin\ffmpeg.exe`.
+2. Crie um `.env` ao lado do executável com `YT_KEY=<CHAVE_DO_STREAM>` (e, se necessário, `YT_URL` ou um caminho alternativo para `FFMPEG`).
+3. Rode `stream_to_youtube.exe` a partir desse diretório e verifique os logs em `C:\bwb\apps\YouTube\logs\bwb_services.log`.
+4. (Opcional) Para manutenção via código-fonte ou geração de novos builds, siga as seções 3 e 4 do mesmo guia.
 
 ### Secondary (Droplet)
 1. Defaults ship in `/usr/local/config/youtube-fallback.defaults`; adjust there if the standard slate settings need to change.

--- a/docs/primary-windows-instalacao.md
+++ b/docs/primary-windows-instalacao.md
@@ -1,58 +1,69 @@
 # Guia de instalação do módulo primário (Windows)
 
-Este guia explica como preparar um host Windows para executar o módulo **primary-windows**, desde a instalação de dependências até a primeira transmissão e empacotamento opcional com o PyInstaller.
+Este guia explica como preparar um host Windows para executar o módulo **primary-windows**, priorizando o uso do executável distribuído (`C:\bwb\apps\YouTube\stream_to_youtube.exe`) e mantendo a execução via código-fonte como alternativa de manutenção.
 
-## 1. Pré-requisitos do host Windows
+## 1. Preparação do host Windows
 
-1. **Instale o Python 3.11**:
-   - Baixe o instalador oficial em <https://www.python.org/downloads/windows/> e escolha a opção *Add python.exe to PATH*.
-   - Verifique a instalação em um *Prompt de Comando* executando `python --version` (deve retornar `Python 3.11.x`).
-2. **Obtenha o código do projeto**:
-   - Via Git: `git clone https://github.com/bubble-wb/bwb-stream2yt.git` e abra o diretório `bwb-stream2yt`.
-   - Via ZIP: faça o download do pacote, extraia para um diretório acessível (ex.: `C:\bwb\bwb-stream2yt`).
-3. **Instale o FFmpeg e configure o caminho padrão**:
+1. **Organize as pastas padrão da BWB**:
+   - Crie `C:\bwb\apps\YouTube\` para armazenar o executável e arquivos auxiliares.
+   - Garanta permissão de escrita para o usuário que operará o serviço (necessário para criação de logs).
+2. **Instale o FFmpeg e configure o caminho padrão**:
    - Crie a pasta `C:\bwb\ffmpeg\bin\`.
    - Copie ou extraia `ffmpeg.exe` (e os demais binários do pacote FFmpeg) para esse diretório.
-   - O script procura automaticamente o executável em `C:\bwb\ffmpeg\bin\ffmpeg.exe` através da variável `FFMPEG`; se preferir outro local, ajuste essa variável manualmente.
+   - O módulo procura o executável em `C:\bwb\ffmpeg\bin\ffmpeg.exe` através da variável `FFMPEG`; se preferir outro local, ajuste essa variável no `.env`.
+3. **(Opcional) Prepare o ambiente de desenvolvimento**:
+   - Instale o Python 3.11 caso seja necessário executar diretamente a partir do código-fonte ou gerar novos builds com o PyInstaller.
+   - Obtenha o repositório `bwb-stream2yt` (via Git ou ZIP) somente se for atuar nessa modalidade.
 
-## 2. Preparação das variáveis de ambiente
+## 2. Executável distribuído
 
-1. No diretório `primary-windows\src\`, copie `example`: `copy .env.example .env`.
-2. Abra o novo arquivo `.env` e preencha as variáveis obrigatórias:
-   - `YT_KEY`: apenas a chave do stream.
-   - `YT_URL`: URL completa `rtmps://a.rtmps.youtube.com/live2/<CHAVE>` (opcional se preferir derivar a partir da `YT_KEY`).
-3. Outros ajustes podem ser feitos no mesmo arquivo (ex.: horários de transmissão, parâmetros de entrada/saída do FFmpeg e caminho do log).
-4. O script `stream_to_youtube.py` carrega o `.env` automaticamente durante a inicialização, portanto não é necessário executar comandos extras para exportar as variáveis.
+1. **Posicione o binário oficial** em `C:\bwb\apps\YouTube\stream_to_youtube.exe`.
+2. **Crie o arquivo de configuração**:
+   - No mesmo diretório do executável, copie `example.env` (quando fornecido) para `.env` ou crie o arquivo manualmente.
+   - Defina ao menos `YT_KEY=<CHAVE_DO_STREAM>`.
+   - Opcionalmente informe `YT_URL` (`rtmps://a.rtmps.youtube.com/live2/<CHAVE>`) caso queira fixar a URL completa.
+   - Ajuste `FFMPEG` apenas se o binário estiver em local diferente do padrão `C:\bwb\ffmpeg\bin\ffmpeg.exe`.
+3. **Execute o serviço**:
+   - Abra um *Prompt de Comando*, navegue até `C:\bwb\apps\YouTube\` e rode `stream_to_youtube.exe`; também é possível criar um atalho ou agendamento apontando para esse caminho.
+   - O `.env` será carregado automaticamente durante a inicialização do executável.
+4. **Verifique os logs**:
+   - Os registros são gravados em `C:\bwb\apps\YouTube\logs\bwb_services.log` (a pasta `logs\` é criada se necessário).
+   - Utilize esse arquivo para confirmar a inicialização do FFmpeg e eventuais erros de autenticação.
+5. **Homologação rápida**:
+   - Confirme, durante o primeiro teste, se o YouTube recebe o stream na URL primária e se o log indica status `connected`.
 
-> Se optar por definir variáveis manualmente (via `set`/`setx`), garanta que correspondam aos nomes acima; valores presentes no `.env` têm precedência quando o arquivo existe.
+## 3. Execução via código-fonte
 
-## 3. Primeira execução e logs
+1. **Requisitos**:
+   - Python 3.11 instalado e acessível no `PATH`.
+   - Repositório `bwb-stream2yt` disponível localmente (clone ou pacote ZIP extraído).
+2. **Configuração do `.env`**:
+   - No diretório `primary-windows\src\`, copie `example.env` (ou `.env.example`) para `.env`.
+   - Preencha as variáveis `YT_KEY` e, se desejado, `YT_URL` e demais parâmetros (`YT_INPUT_ARGS`, `YT_OUTPUT_ARGS`, `FFMPEG`, etc.).
+3. **Execução**:
+   - Abra um *Prompt de Comando* em `primary-windows\src\` e execute `python stream_to_youtube.py`.
+   - O log compartilhado é gravado em `primary-windows\src\logs\bwb_services.log`.
+4. **Validação**:
+   - Monitore o mesmo log para verificar a inicialização do FFmpeg e confirme a recepção do stream no painel do YouTube.
 
-1. Abra um *Prompt de Comando* e navegue até `primary-windows\src\`.
-2. Execute o script com o Python 3.11: `python stream_to_youtube.py`.
-3. O log compartilhado é gravado em `logs\bwb_services.log` ao lado do script. A pasta é criada automaticamente se não existir.
-4. Durante o primeiro teste, verifique no log as mensagens de inicialização do FFmpeg e confirme na interface do YouTube que o stream está conectado à URL primária.
-
-## 4. Build one-file com PyInstaller
+## 4. Build one-file com PyInstaller (referência)
 
 1. Instale o PyInstaller (exige Python 3.11):
    ```bat
    py -3.11 -m pip install -U pip wheel
    py -3.11 -m pip install -U pyinstaller==6.10
    ```
-2. Gere o executável: `py -3.11 -m PyInstaller --clean --onefile src/stream_to_youtube.py`.
-3. O binário será produzido em `dist/stream_to_youtube.exe`.
-4. Para execução, posicione um `.env` atualizado no mesmo diretório do `.exe` (ou defina as variáveis no ambiente) e mantenha o diretório `logs\` acessível para escrita.
-5. Ao distribuir o executável, inclua uma verificação manual da presença de `ffmpeg.exe` em `C:\bwb\ffmpeg\bin\` ou documente o caminho alternativo via variável `FFMPEG`.
+2. Gere o executável a partir do diretório `primary-windows\`: `py -3.11 -m PyInstaller --clean --onefile src/stream_to_youtube.py`.
+3. O binário será produzido em `dist/stream_to_youtube.exe` e deve ser movido para `C:\bwb\apps\YouTube\` junto com um `.env` válido.
+4. Durante a distribuição, reforce a necessidade do `ffmpeg.exe` presente em `C:\bwb\ffmpeg\bin\` ou documente o caminho alternativo via variável `FFMPEG`.
 
 ## 5. Checklist de verificação
 
-- [ ] Python 3.11 instalado e reportando a versão correta.
-- [ ] Repositório disponível localmente (clone ou ZIP extraído).
-- [ ] `ffmpeg.exe` presente em `C:\bwb\ffmpeg\bin\` e acessível.
-- [ ] Arquivo `primary-windows\src\.env` preenchido com `YT_KEY` (e opcionalmente `YT_URL`).
-- [ ] Execução de `python stream_to_youtube.py` gera logs em `logs\bwb_services.log`.
-- [ ] Dashboard do YouTube confirma conexão na URL primária durante o teste.
-- [ ] (Opcional) Build `stream_to_youtube.exe` criado e `.env` copiado para o diretório do binário.
+- [ ] `stream_to_youtube.exe` posicionado em `C:\bwb\apps\YouTube\`.
+- [ ] `.env` criado no mesmo diretório com `YT_KEY` (e, se necessário, `YT_URL`/`FFMPEG`).
+- [ ] `ffmpeg.exe` disponível em `C:\bwb\ffmpeg\bin\` ou caminho ajustado na configuração.
+- [ ] Execução do executável gera `C:\bwb\apps\YouTube\logs\bwb_services.log` sem erros críticos.
+- [ ] Dashboard do YouTube confirma conexão do stream durante o teste.
+- [ ] (Opcional) Ambiente Python 3.11 preparado para manutenção via código-fonte ou geração de novos builds.
 
-Seguindo estes passos o host Windows estará pronto para transmitir pelo módulo primário com segurança e previsibilidade.
+Seguindo estes passos, o host Windows estará pronto para transmitir pelo módulo primário com segurança e previsibilidade, seja utilizando o executável distribuído ou o código-fonte.

--- a/primary-windows/README.md
+++ b/primary-windows/README.md
@@ -4,6 +4,13 @@ Ferramenta oficial para enviar o feed (RTSP/DirectShow) para a URL **primária**
 
 ## Utilização rápida
 
+### Executável distribuído
+
+- Siga o [guia de instalação](../docs/primary-windows-instalacao.md#2-executável-distribuído) para posicionar o `stream_to_youtube.exe` em `C:\bwb\apps\YouTube\`, criar o `.env` ao lado do binário e apontar para o FFmpeg em `C:\bwb\ffmpeg\bin\ffmpeg.exe`.
+- A execução gera logs em `C:\bwb\apps\YouTube\logs\bwb_services.log`. Utilize-os para homologar a conexão com o YouTube.
+
+### Código-fonte (desenvolvimento)
+
 1. Configure as variáveis de ambiente:
    - Copie `src/.env.example` para `src/.env` e edite `YT_URL` ou `YT_KEY`; ou
    - Defina-as manualmente antes de executar (`set YT_KEY=xxxx`).


### PR DESCRIPTION
## Summary
- reorganize o guia de instalação do primary-windows no Windows priorizando o uso do executável distribuído
- ajuste a checklist e inclua detalhes sobre posicionamento do .env, caminho do FFmpeg e localização dos logs
- atualize os apontamentos no docs/README.md e no primary-windows/README.md para refletir as novas seções do guia

## Testing
- not run (documentação apenas)


------
https://chatgpt.com/codex/tasks/task_e_68e1d21356c88322a4b28c20036defe3