### PR TITLE
Add log rotation housekeeping for primary Windows sender

### DIFF
--- a/docs/primary-windows-instalacao.md
+++ b/docs/primary-windows-instalacao.md
@@ -27,8 +27,8 @@ Este guia explica como preparar um host Windows para executar o módulo **primar
    - Abra um *Prompt de Comando*, navegue até `C:\bwb\apps\YouTube\` e rode `stream_to_youtube.exe`; também é possível criar um atalho ou agendamento apontando para esse caminho.
    - O `.env` será carregado automaticamente durante a inicialização do executável.
 4. **Verifique os logs**:
-   - Os registros são gravados em `C:\bwb\apps\YouTube\logs\bwb_services.log` (a pasta `logs\` é criada se necessário).
-   - Utilize esse arquivo para confirmar a inicialização do FFmpeg e eventuais erros de autenticação.
+   - Os registros são gravados em arquivos diários `C:\bwb\apps\YouTube\logs\bwb_services-YYYY-MM-DD.log` (a pasta `logs\` é criada se necessário e mantemos somente os últimos sete dias).
+   - Utilize esses arquivos para confirmar a inicialização do FFmpeg e eventuais erros de autenticação.
 5. **Homologação rápida**:
    - Confirme, durante o primeiro teste, se o YouTube recebe o stream na URL primária e se o log indica status `connected`.
 
@@ -42,7 +42,7 @@ Este guia explica como preparar um host Windows para executar o módulo **primar
    - Preencha as variáveis `YT_KEY` e, se desejado, `YT_URL` e demais parâmetros (`YT_INPUT_ARGS`, `YT_OUTPUT_ARGS`, `FFMPEG`, etc.).
 3. **Execução**:
    - Abra um *Prompt de Comando* em `primary-windows\src\` e execute `python stream_to_youtube.py`.
-   - O log compartilhado é gravado em `primary-windows\src\logs\bwb_services.log`.
+   - O log compartilhado é gravado em arquivos diários `primary-windows\src\logs\bwb_services-YYYY-MM-DD.log` com retenção automática de sete dias.
 4. **Validação**:
    - Monitore o mesmo log para verificar a inicialização do FFmpeg e confirme a recepção do stream no painel do YouTube.
 
@@ -62,7 +62,7 @@ Este guia explica como preparar um host Windows para executar o módulo **primar
 - [ ] `stream_to_youtube.exe` posicionado em `C:\bwb\apps\YouTube\`.
 - [ ] `.env` criado no mesmo diretório com `YT_KEY` (e, se necessário, `YT_URL`/`FFMPEG`).
 - [ ] `ffmpeg.exe` disponível em `C:\bwb\ffmpeg\bin\` ou caminho ajustado na configuração.
-- [ ] Execução do executável gera `C:\bwb\apps\YouTube\logs\bwb_services.log` sem erros críticos.
+- [ ] Execução do executável gera arquivos `C:\bwb\apps\YouTube\logs\bwb_services-YYYY-MM-DD.log` (com retenção automática de sete dias) sem erros críticos.
 - [ ] Dashboard do YouTube confirma conexão do stream durante o teste.
 - [ ] (Opcional) Ambiente Python 3.11 preparado para manutenção via código-fonte ou geração de novos builds.
 

--- a/primary-windows/README.md
+++ b/primary-windows/README.md
@@ -7,7 +7,7 @@ Ferramenta oficial para enviar o feed (RTSP/DirectShow) para a URL **primária**
 ### Executável distribuído
 
 - Siga o [guia de instalação](../docs/primary-windows-instalacao.md#2-executável-distribuído) para posicionar o `stream_to_youtube.exe` em `C:\bwb\apps\YouTube\`, criar o `.env` ao lado do binário e apontar para o FFmpeg em `C:\bwb\ffmpeg\bin\ffmpeg.exe`.
-- A execução gera logs em `C:\bwb\apps\YouTube\logs\bwb_services.log`. Utilize-os para homologar a conexão com o YouTube.
+- A execução gera arquivos diários em `C:\bwb\apps\YouTube\logs\bwb_services-YYYY-MM-DD.log` (retenção automática de sete dias). Utilize-os para homologar a conexão com o YouTube.
 
 ### Código-fonte (desenvolvimento)
 
@@ -28,9 +28,8 @@ Ferramenta oficial para enviar o feed (RTSP/DirectShow) para a URL **primária**
 - `YT_DAY_START_HOUR`, `YT_DAY_END_HOUR` e `YT_TZ_OFFSET_HOURS` controlam a janela de transmissão.
 - `YT_INPUT_ARGS` / `YT_OUTPUT_ARGS` permitem ajustar os argumentos do ffmpeg.
 - `FFMPEG` aponta para o executável do ffmpeg (por omissão `C:\bwb\ffmpeg\bin\ffmpeg.exe`).
-- `BWB_LOG_FILE` define onde o log compartilhado é gravado. Por padrão usamos
-  `logs/bwb_services.log` ao lado do script/executável, criando a pasta
-  automaticamente no Windows.
+- `BWB_LOG_FILE` define o caminho base dos logs. Gravamos arquivos diários no formato
+  `<nome>-YYYY-MM-DD.log` e mantemos automaticamente somente os últimos sete dias.
 
 ## Build (one-file) com PyInstaller
 


### PR DESCRIPTION
## Summary
- add a housekeeping routine that rotates shared logs into daily files and prunes entries older than seven days
- update `log_event` to invoke the new pruning step before writing each entry
- document the daily log naming scheme and retention policy in the Windows primary module guides

## Testing
- python -m compileall primary-windows/src/stream_to_youtube.py

------
https://chatgpt.com/codex/tasks/task_e_68e1d512f85483228bea5e216d200c8d