### PR TITLE
Automate primary Windows env bootstrap

### DIFF
--- a/docs/primary-windows-instalacao.md
+++ b/docs/primary-windows-instalacao.md
@@ -18,11 +18,10 @@ Este guia explica como preparar um host Windows para executar o módulo **primar
 ## 2. Executável distribuído
 
 1. **Posicione o binário oficial** em `C:\bwb\apps\YouTube\stream_to_youtube.exe`.
-2. **Crie o arquivo de configuração**:
-   - No mesmo diretório do executável, copie `example.env` (quando fornecido) para `.env` ou crie o arquivo manualmente.
-   - Defina ao menos `YT_KEY=<CHAVE_DO_STREAM>`.
-   - Opcionalmente informe `YT_URL` (`rtmps://a.rtmps.youtube.com/live2/<CHAVE>`) caso queira fixar a URL completa.
-   - Ajuste `FFMPEG` apenas se o binário estiver em local diferente do padrão `C:\bwb\ffmpeg\bin\ffmpeg.exe`.
+2. **Ajuste o arquivo de configuração**:
+   - Ao executar o binário pela primeira vez, o script cria automaticamente um `.env` no mesmo diretório usando o template padrão.
+   - Em seguida, edite o `.env` recém-criado e configure ao menos `YT_KEY=<CHAVE_DO_STREAM>` (ou `YT_URL` completo, se preferir).
+   - Ajuste `YT_INPUT_ARGS`, `YT_OUTPUT_ARGS`, as credenciais RTSP e `FFMPEG` conforme a necessidade do equipamento local.
 3. **Execute o serviço**:
    - Abra um *Prompt de Comando*, navegue até `C:\bwb\apps\YouTube\` e rode `stream_to_youtube.exe`; também é possível criar um atalho ou agendamento apontando para esse caminho.
    - O `.env` será carregado automaticamente durante a inicialização do executável.
@@ -38,8 +37,8 @@ Este guia explica como preparar um host Windows para executar o módulo **primar
    - Python 3.11 instalado e acessível no `PATH`.
    - Repositório `bwb-stream2yt` disponível localmente (clone ou pacote ZIP extraído).
 2. **Configuração do `.env`**:
-   - No diretório `primary-windows\src\`, copie `example.env` (ou `.env.example`) para `.env`.
-   - Preencha as variáveis `YT_KEY` e, se desejado, `YT_URL` e demais parâmetros (`YT_INPUT_ARGS`, `YT_OUTPUT_ARGS`, `FFMPEG`, etc.).
+   - A primeira execução de `python stream_to_youtube.py` cria automaticamente `primary-windows\src\.env` com o template padrão.
+   - Edite o arquivo para preencher `YT_KEY` (ou `YT_URL`) e personalize os parâmetros `YT_INPUT_ARGS`, `YT_OUTPUT_ARGS`, credenciais RTSP e `FFMPEG` conforme necessário.
 3. **Execução**:
    - Abra um *Prompt de Comando* em `primary-windows\src\` e execute `python stream_to_youtube.py`.
    - O log compartilhado é gravado em arquivos diários `primary-windows\src\logs\bwb_services-YYYY-MM-DD.log` com retenção automática de sete dias.
@@ -60,7 +59,7 @@ Este guia explica como preparar um host Windows para executar o módulo **primar
 ## 5. Checklist de verificação
 
 - [ ] `stream_to_youtube.exe` posicionado em `C:\bwb\apps\YouTube\`.
-- [ ] `.env` criado no mesmo diretório com `YT_KEY` (e, se necessário, `YT_URL`/`FFMPEG`).
+- [ ] `.env` ajustado no mesmo diretório com `YT_KEY` (e, se necessário, `YT_URL`/`FFMPEG`).
 - [ ] `ffmpeg.exe` disponível em `C:\bwb\ffmpeg\bin\` ou caminho ajustado na configuração.
 - [ ] Execução do executável gera arquivos `C:\bwb\apps\YouTube\logs\bwb_services-YYYY-MM-DD.log` (com retenção automática de sete dias) sem erros críticos.
 - [ ] Dashboard do YouTube confirma conexão do stream durante o teste.

--- a/primary-windows/README.md
+++ b/primary-windows/README.md
@@ -6,14 +6,14 @@ Ferramenta oficial para enviar o feed (RTSP/DirectShow) para a URL **primária**
 
 ### Executável distribuído
 
-- Siga o [guia de instalação](../docs/primary-windows-instalacao.md#2-executável-distribuído) para posicionar o `stream_to_youtube.exe` em `C:\bwb\apps\YouTube\`, criar o `.env` ao lado do binário e apontar para o FFmpeg em `C:\bwb\ffmpeg\bin\ffmpeg.exe`.
+- Siga o [guia de instalação](../docs/primary-windows-instalacao.md#2-executável-distribuído) para posicionar o `stream_to_youtube.exe` em `C:\bwb\apps\YouTube\`. A primeira execução gera automaticamente o `.env` ao lado do binário; edite-o em seguida para informar `YT_KEY`/`YT_URL`, argumentos do FFmpeg e credenciais RTSP conforme o equipamento.
 - A execução gera arquivos diários em `C:\bwb\apps\YouTube\logs\bwb_services-YYYY-MM-DD.log` (retenção automática de sete dias). Utilize-os para homologar a conexão com o YouTube.
 
 ### Código-fonte (desenvolvimento)
 
 1. Configure as variáveis de ambiente:
-   - Copie `src/.env.example` para `src/.env` e edite `YT_URL` ou `YT_KEY`; ou
-   - Defina-as manualmente antes de executar (`set YT_KEY=xxxx`).
+   - A primeira execução gera `src/.env` automaticamente a partir do template `src/.env.example`; edite `YT_URL`/`YT_KEY`, argumentos e credenciais antes de iniciar a transmissão.
+   - Alternativamente, defina as variáveis manualmente antes de executar (`set YT_KEY=xxxx`).
 2. Execute a partir de `primary-windows/src/` (o `.env` é lido automaticamente):
    ```bat
    setlocal

--- a/primary-windows/src/.env.example
+++ b/primary-windows/src/.env.example
@@ -1,16 +1,21 @@
-# Variáveis necessárias para stream_to_youtube.py
-# Copie para .env e ajuste.
+# Configurações para stream_to_youtube.py
+# Copie este arquivo para ".env" ou deixe que o script gere um automaticamente e depois personalize.
 
-# URL completo (altere se preferir fornecer o URL inteiro)
-#YT_URL=rtmps://a.rtmps.youtube.com/live2/AAAAAAAA-BBBB-CCCC-DDDD-EEEE
+# Chave do YouTube Live. Se preenchida, a URL final será gerada automaticamente.
+#YT_KEY=SEU_CODIGO_DO_YOUTUBE
 
-# Ou apenas a chave do stream (o URL é calculado automaticamente)
-YT_KEY=INSIRA_A_SUA_CHAVE_AQUI
+# URL completa do ingest RTMP. Use se preferir definir manualmente em vez da chave.
+#YT_URL=rtmps://a.rtmps.youtube.com/live2/SEU_CODIGO_DO_YOUTUBE
 
-# --- Opcional: overrides ---
-#YT_DAY_START_HOUR=8
-#YT_DAY_END_HOUR=19
-#YT_TZ_OFFSET_HOURS=1
-#YT_INPUT_ARGS=-re -f lavfi -i testsrc2=size=1280x720:rate=30
-#YT_OUTPUT_ARGS=-c:v libx264 -preset veryfast -pix_fmt yuv420p -b:v 2500k -g 60 -c:a aac -b:a 128k -ar 48000 -ac 2
-#FFMPEG=C:\\bwb\\ffmpeg\\bin\\ffmpeg.exe
+# Parâmetros de entrada para o ffmpeg. Ajuste o endereço RTSP conforme necessário.
+#YT_INPUT_ARGS=-rtsp_transport tcp -rtsp_flags prefer_tcp -fflags nobuffer -flags low_delay -use_wallclock_as_timestamps 1 -i rtsp://USUARIO:SenhaFort3@10.0.254.50:554/Streaming/Channels/101
+
+# Parâmetros de saída para o ffmpeg. Utilize para alterar codec, bitrate ou filtros.
+#YT_OUTPUT_ARGS=-vf scale=1920:1080:flags=bicubic,format=yuv420p -r 30 -c:v libx264 -preset veryfast -profile:v high -level 4.2 -b:v 4500k -pix_fmt yuv420p -g 60 -c:a aac -b:a 128k -ar 44100 -f flv
+
+# Caminho para o executável ffmpeg. Deixe vazio para usar o ffmpeg no PATH.
+#FFMPEG=C:\\caminho\\para\\ffmpeg.exe
+
+# Credenciais RTSP padrão (exemplo). Substitua conforme o dispositivo utilizado.
+#RTSP_USERNAME=USUARIO
+#RTSP_PASSWORD=SenhaFort3


### PR DESCRIPTION
## Summary
- refresh the Windows primary sender .env template with detailed guidance for FFmpeg and RTSP settings
- ensure stream_to_youtube.py creates a starter .env when missing using either the bundled template or an embedded fallback
- update Windows operator docs to explain the automatic .env creation and required post-run edits

## Testing
- python -m compileall primary-windows/src/stream_to_youtube.py

------
https://chatgpt.com/codex/tasks/task_e_68e1d5e670508322a2db82b4729b1820