### PR TITLE
Add tray-controlled streaming worker for Windows primary sender

### DIFF
--- a/primary-windows/README.md
+++ b/primary-windows/README.md
@@ -4,6 +4,8 @@ Ferramenta oficial para enviar o feed (RTSP/DirectShow) para a URL **primária**
 
 ## Utilização rápida
 
+- O executável agora roda em **modo bandeja** e controla a transmissão em segundo plano. O ícone exibe as opções "Abrir logs…", "Parar/Iniciar transmissão" e "Sair"; sair garante o encerramento limpo do FFmpeg.
+
 ### Executável distribuído
 
 - Siga o [guia de instalação](../docs/primary-windows-instalacao.md#2-executável-distribuído) para posicionar o `stream_to_youtube.exe` em `C:\bwb\apps\YouTube\`. A primeira execução gera automaticamente o `.env` ao lado do binário; edite-o em seguida para informar `YT_KEY`/`YT_URL`, argumentos do FFmpeg e credenciais RTSP conforme o equipamento.
@@ -15,11 +17,18 @@ Ferramenta oficial para enviar o feed (RTSP/DirectShow) para a URL **primária**
    - A primeira execução gera `src/.env` automaticamente a partir do template `src/.env.example`; edite `YT_URL`/`YT_KEY`, argumentos e credenciais antes de iniciar a transmissão.
    - Alternativamente, defina as variáveis manualmente antes de executar (`set YT_KEY=xxxx`).
 2. Execute a partir de `primary-windows/src/` (o `.env` é lido automaticamente):
-   ```bat
-   setlocal
-   cd /d %~dp0src
-   python stream_to_youtube.py
-   ```
+   - Para depurar no console:
+     ```bat
+     setlocal
+     cd /d %~dp0src
+     python -c "from stream_to_youtube import run_forever; run_forever()"
+     ```
+   - Para testar o modo bandeja durante o desenvolvimento (requer ambiente gráfico):
+     ```bat
+     setlocal
+     cd /d %~dp0src
+     pythonw stream_to_youtube.py
+     ```
 
 ## Configuração (variáveis opcionais)
 
@@ -34,14 +43,14 @@ Ferramenta oficial para enviar o feed (RTSP/DirectShow) para a URL **primária**
 ## Build (one-file) com PyInstaller
 
 - Use Python 3.11 para evitar problemas do 3.13 com o PyInstaller.
-- Instale dependências e faça o build:
+- Instale dependências (incluindo `pystray` e `pillow`, necessários para a bandeja) e faça o build:
 
 ```bat
 py -3.11 -m pip install -U pip wheel
-py -3.11 -m pip install -U pyinstaller==6.10
-py -3.11 -m PyInstaller --clean --onefile src/stream_to_youtube.py
+py -3.11 -m pip install -U pyinstaller==6.10 pystray pillow
+py -3.11 -m PyInstaller --clean --onefile --noconsole src/stream_to_youtube.py
 ```
 
-O executável ficará em `dist/stream_to_youtube.exe`.
+O executável ficará em `dist/stream_to_youtube.exe` pronto para execução silenciosa via `pythonw.exe`.
 
 > ⚠️ Antes de lançar o `.exe`, certifique-se de que `YT_URL` ou `YT_KEY` estão definidos no ambiente ou num `.env` ao lado do executável. Nunca embuta chaves no binário.

--- a/primary-windows/src/system_tray.py
+++ b/primary-windows/src/system_tray.py
@@ -1,0 +1,101 @@
+"""System tray integration for the Windows primary streaming worker."""
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+try:
+    import pystray
+    from PIL import Image, ImageDraw
+except ImportError as exc:  # pragma: no cover - handled via docs/runtime
+    raise RuntimeError(
+        "pystray e pillow são necessários para o modo bandeja. Instale-os antes de executar."
+    ) from exc
+
+from stream_to_youtube import LOG_DIR, log_event
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from stream_to_youtube import StreamingWorker
+
+
+class TrayApplication:
+    """Wrapper that exposes the streaming worker controls on the system tray."""
+
+    def __init__(self, worker: "StreamingWorker") -> None:
+        self._worker = worker
+        self._icon = pystray.Icon(
+            "bwb_stream_to_youtube",
+            self._create_image(),
+            "BWB Stream2YT",
+            self._build_menu(),
+        )
+
+    def run(self) -> None:
+        """Start the tray icon loop (blocking)."""
+
+        log_event("tray", "Tray icon iniciado")
+        self._icon.run()
+
+    def stop(self) -> None:
+        """Stop the tray icon loop."""
+
+        self._icon.stop()
+
+    # Menu helpers -----------------------------------------------------
+    def _build_menu(self) -> pystray.Menu:
+        return pystray.Menu(
+            pystray.MenuItem("Abrir logs…", self._on_open_logs),
+            pystray.MenuItem(self._toggle_label, self._on_toggle_stream, default=False),
+            pystray.MenuItem("Sair", self._on_exit),
+        )
+
+    def _toggle_label(self, item: pystray.MenuItem) -> str:
+        return "Parar transmissão" if self._worker.is_running else "Iniciar transmissão"
+
+    def _refresh_menu(self) -> None:
+        self._icon.update_menu()
+
+    # Actions ----------------------------------------------------------
+    def _on_open_logs(self, icon: pystray.Icon, item: pystray.MenuItem) -> None:
+        LOG_DIR.mkdir(parents=True, exist_ok=True)
+        target = LOG_DIR if LOG_DIR.is_dir() else LOG_DIR.parent
+        log_event("tray", f"Abrindo pasta de logs em {target}")
+        self._open_path(target)
+
+    def _on_toggle_stream(self, icon: pystray.Icon, item: pystray.MenuItem) -> None:
+        if self._worker.is_running:
+            log_event("tray", "Solicitado stop do streaming via bandeja")
+            self._worker.stop()
+        else:
+            log_event("tray", "Solicitado start do streaming via bandeja")
+            self._worker.start()
+        self._refresh_menu()
+
+    def _on_exit(self, icon: pystray.Icon, item: pystray.MenuItem) -> None:
+        log_event("tray", "Encerrando aplicação via bandeja")
+        self._worker.stop()
+        self.stop()
+
+    # Utilities --------------------------------------------------------
+    def _open_path(self, path: Path) -> None:
+        try:
+            os.startfile(path)  # type: ignore[attr-defined]
+        except AttributeError:
+            if os.name == "posix":
+                subprocess.Popen(["xdg-open", str(path)])
+            elif os.name == "darwin":
+                subprocess.Popen(["open", str(path)])
+            else:
+                raise
+        except OSError as exc:
+            log_event("tray", f"Não foi possível abrir os logs: {exc}")
+
+    def _create_image(self) -> Image.Image:
+        size = 64
+        image = Image.new("RGBA", (size, size), (0, 0, 0, 0))
+        draw = ImageDraw.Draw(image)
+        draw.ellipse((4, 4, size - 4, size - 4), fill=(220, 0, 0, 255))
+        draw.rectangle((size // 3, size // 3, size * 2 // 3, size * 2 // 3), fill=(255, 255, 255, 255))
+        return image


### PR DESCRIPTION
## Summary
- refactor the Windows primary streamer into a reusable `StreamingWorker` that can run in the background
- add a system tray controller with logging, start/stop toggles, and safe shutdown handling
- document tray usage, development options, and updated PyInstaller requirements

## Testing
- python -m compileall primary-windows/src

------
https://chatgpt.com/codex/tasks/task_e_68e1db9b3ac483228249500ea387c960