### PR TITLE
docs: alinhar instruções de build do primary windows

### DIFF
--- a/docs/primary-windows-instalacao.md
+++ b/docs/primary-windows-instalacao.md
@@ -47,11 +47,12 @@ Este guia explica como preparar um host Windows para executar o módulo **primar
 
 ## 4. Build one-file com PyInstaller (referência)
 
-1. Instale o PyInstaller (exige Python 3.11):
+1. Instale o PyInstaller e as dependências necessárias (exige Python 3.11):
    ```bat
    py -3.11 -m pip install -U pip wheel
-   py -3.11 -m pip install -U pyinstaller==6.10
+   py -3.11 -m pip install -U pyinstaller==6.10 pystray pillow
    ```
+   > `pystray` e `pillow` precisam estar disponíveis porque `primary-windows\src\system_tray.py` os importa durante a inicialização do executável.
 2. Gere o executável a partir do diretório `primary-windows\`: `py -3.11 -m PyInstaller --clean --onefile src/stream_to_youtube.py`.
 3. O binário será produzido em `dist/stream_to_youtube.exe` e deve ser movido para `C:\bwb\apps\YouTube\` junto com um `.env` válido.
 4. Durante a distribuição, reforce a necessidade do `ffmpeg.exe` presente em `C:\bwb\ffmpeg\bin\` ou documente o caminho alternativo via variável `FFMPEG`.


### PR DESCRIPTION
## Summary
- clarify the Windows build instructions to install pyinstaller together with the pystray and pillow dependencies used by the tray icon
- note why pystray and pillow are required at startup

## Testing
- `python -m PyInstaller --clean --onefile src/stream_to_youtube.py`
- `./dist/stream_to_youtube --help`


------
https://chatgpt.com/codex/tasks/task_e_68e1dee6b0548322b8d9486f731a04c6