### PR TITLE
Add offline Windows build kit instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,16 @@ logs/
 # OS
 .DS_Store
 
+# Windows offline kit (ignore generated artifacts but keep documentation)
+primary-windows/via-windows/
+!primary-windows/via-windows/
+primary-windows/via-windows/*
+!primary-windows/via-windows/README.md
+!primary-windows/via-windows/requirements.txt
+!primary-windows/via-windows/stream_to_youtube.spec
+!primary-windows/via-windows/build.bat
+!primary-windows/via-windows/prepare-env.bat
+
 # Secrets
 *.env
 **/secrets/**

--- a/docs/primary-windows-instalacao.md
+++ b/docs/primary-windows-instalacao.md
@@ -50,22 +50,11 @@ Este guia explica como preparar um host Windows para executar o módulo **primar
 
 ## 4. Build one-file com PyInstaller (referência)
 
-1. Instale o PyInstaller e as dependências necessárias (exige Python 3.11):
-   ```bat
-   py -3.11 -m pip install -U pip wheel
-   py -3.11 -m pip install -U pyinstaller==6.10 pywin32 pyinstaller-hooks-contrib
-   ```
-2. Gere o executável a partir do diretório `primary-windows\`:
-   ```bat
-   py -3.11 -m PyInstaller --clean --onefile --noconsole ^
-       --hidden-import win32timezone ^
-       --collect-binaries pywin32 ^
-       --collect-submodules win32service ^
-       --collect-submodules win32timezone ^
-       src/stream_to_youtube.py
-   ```
-   Essas opções incorporam todas as dependências do `pywin32`; sem elas, o executável não inclui os binários necessários e os comandos `/service` falham ao registrar o serviço.
-3. O binário será produzido em `dist/stream_to_youtube.exe` e deve ser movido para `C:\bwb\apps\YouTube\` junto com um `.env` válido.
+Para gerar o executável sem acesso à internet, utilize o kit de build localizado em [`primary-windows/via-windows/`](../primary-windows/via-windows/README.md):
+
+1. Instale o Python 3.11 e siga o passo a passo descrito no `README.md` do diretório `via-windows` (ou execute `prepare-env.bat` e `build.bat`).
+2. O spec file `stream_to_youtube.spec` encapsula os mesmos parâmetros da nossa pipeline (`--onefile`, `--noconsole`, `--hidden-import win32timezone`, `--collect-binaries pywin32`, etc.), garantindo que `pywin32` e demais dependências sejam embaladas corretamente.
+3. Ao término do processo, copie `primary-windows\via-windows\dist\stream_to_youtube.exe` para `C:\bwb\apps\YouTube\` juntamente com um `.env` atualizado.
 4. Durante a distribuição, reforce a necessidade do `ffmpeg.exe` presente em `C:\bwb\ffmpeg\bin\` ou documente o caminho alternativo via variável `FFMPEG`.
 
 ## 5. Checklist de verificação

--- a/primary-windows/README.md
+++ b/primary-windows/README.md
@@ -53,20 +53,8 @@ O serviço executa o mesmo worker da versão em foreground (com logs em `logs\bw
 
 ## Build (one-file) com PyInstaller
 
-- Use Python 3.11 para evitar problemas do 3.13 com o PyInstaller.
-- Instale dependências e faça o build:
-
-```bat
-py -3.11 -m pip install -U pip wheel
-py -3.11 -m pip install -U pyinstaller==6.10 pywin32 pyinstaller-hooks-contrib
-py -3.11 -m PyInstaller --clean --onefile --noconsole ^
-    --hidden-import win32timezone ^
-    --collect-binaries pywin32 ^
-    --collect-submodules win32service ^
-    --collect-submodules win32timezone ^
-    src/stream_to_youtube.py
-```
-
-O executável ficará em `dist/stream_to_youtube.exe` pronto para execução silenciosa via `pythonw.exe`.
+- Utilize o kit offline documentado em [`primary-windows/via-windows/`](./via-windows/README.md) para reproduzir o executável oficial com Python 3.11, requirements e o `stream_to_youtube.spec` configurado com os mesmos parâmetros da pipeline.
+- O `build.bat` presente nesse diretório executa o PyInstaller com `--onefile`, `--noconsole` e inclui automaticamente os binários do `pywin32`, gerando `dist/stream_to_youtube.exe` pronto para distribuição.
+- O script `prepare-env.bat` cria o ambiente virtual e instala as dependências necessárias antes do build.
 
 > ⚠️ Antes de lançar o `.exe`, certifique-se de que `YT_URL` ou `YT_KEY` estão definidos no ambiente ou num `.env` ao lado do executável. Nunca embuta chaves no binário.

--- a/primary-windows/via-windows/README.md
+++ b/primary-windows/via-windows/README.md
@@ -1,0 +1,59 @@
+# Offline Windows Build Kit
+
+These instructions describe how to package the **stream_to_youtube** Windows executable using a fully offline-capable toolchain. The process mirrors the flags and configuration used by the official automation so developers can reproduce the artifact in an isolated Windows workstation.
+
+## Prerequisites
+
+1. Windows 10 or newer with administrator privileges.
+2. Python 3.11.x from <https://www.python.org/downloads/windows/> installed for "All Users" with the "Add python.exe to PATH" option enabled.
+3. Local copy of this repository synced to `C:\bwb\src\stream2yt\` (or another working directory of your choice).
+
+## 1. Prepare the virtual environment
+
+```powershell
+cd C:\bwb\src\stream2yt\primary-windows\via-windows
+python -m venv .venv
+.venv\Scripts\activate
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+```
+
+> 💡 If you prefer to automate the bootstrap process, run `prepare-env.bat` instead of executing the commands manually.
+
+## 2. Build the executable with PyInstaller
+
+With the virtual environment activated, invoke PyInstaller using the provided spec file:
+
+```powershell
+pyinstaller stream_to_youtube.spec
+```
+
+The spec file already captures the CLI flags we normally pass (`--onefile`, `--noconsole`, hidden imports, and collected binaries). The resulting binary will be written to:
+
+```
+primary-windows\via-windows\dist\stream_to_youtube.exe
+```
+
+Alternatively, execute `build.bat` to run the same command sequence automatically.
+
+## 3. Publish the binary to the YouTube app directory
+
+Copy the generated executable to the target offline location expected by the Windows primary deployment:
+
+```powershell
+Copy-Item dist\stream_to_youtube.exe C:\bwb\apps\YouTube\stream_to_youtube.exe -Force
+```
+
+You can now distribute `C:\bwb\apps\YouTube\stream_to_youtube.exe` to operators or bundle it with the installation media.
+
+## 4. Clean up (optional)
+
+To reclaim disk space, you may remove the `build\` directory that PyInstaller creates or delete the entire virtual environment:
+
+```powershell
+Remove-Item -Recurse -Force build .venv
+```
+
+---
+
+For additional background on the application, see [`primary-windows/README.md`](../README.md) and [`docs/primary-windows-instalacao.md`](../../docs/primary-windows-instalacao.md).

--- a/primary-windows/via-windows/build.bat
+++ b/primary-windows/via-windows/build.bat
@@ -1,0 +1,20 @@
+@echo off
+setlocal
+
+if not exist .venv (
+    echo [error] Virtual environment not found. Run prepare-env.bat first.
+    exit /b 1
+)
+
+call .venv\Scripts\activate.bat
+
+pyinstaller stream_to_youtube.spec
+
+if %errorlevel% neq 0 (
+    echo [error] PyInstaller build failed.
+    exit /b %errorlevel%
+)
+
+echo [done] Binary available at %cd%\dist\stream_to_youtube.exe
+
+endlocal

--- a/primary-windows/via-windows/prepare-env.bat
+++ b/primary-windows/via-windows/prepare-env.bat
@@ -1,0 +1,14 @@
+@echo off
+setlocal enabledelayedexpansion
+
+if not exist .venv (
+    echo [setup] Creating Python 3.11 virtual environment...
+    py -3.11 -m venv .venv
+)
+
+call .venv\Scripts\activate.bat
+
+python -m pip install --upgrade pip
+python -m pip install --no-warn-script-location -r requirements.txt
+
+endlocal

--- a/primary-windows/via-windows/requirements.txt
+++ b/primary-windows/via-windows/requirements.txt
@@ -1,0 +1,6 @@
+# Windows-specific build dependencies for reproducing the stream_to_youtube.exe binary
+pyinstaller==6.10.0
+pyinstaller-hooks-contrib==2024.7
+pywin32==306
+pywin32-ctypes==0.2.2
+pefile==2023.2.7

--- a/primary-windows/via-windows/stream_to_youtube.spec
+++ b/primary-windows/via-windows/stream_to_youtube.spec
@@ -1,0 +1,57 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller build configuration for the Windows primary executable.
+
+This mirrors the CLI invocation:
+pyinstaller --onefile --noconsole --hidden-import win32timezone --collect-binaries pywin32 \
+    primary-windows/src/stream_to_youtube.py
+"""
+
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_all
+
+block_cipher = None
+
+BASE_DIR = Path(__file__).resolve().parent
+SRC_DIR = (BASE_DIR / ".." / "src").resolve()
+SCRIPT = SRC_DIR / "stream_to_youtube.py"
+
+pywin32_datas, pywin32_binaries, pywin32_hiddenimports = collect_all("pywin32")
+
+analysis = Analysis(
+    [str(SCRIPT)],
+    pathex=[str(SRC_DIR)],
+    binaries=pywin32_binaries,
+    datas=pywin32_datas,
+    hiddenimports=["win32timezone", *pywin32_hiddenimports],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(analysis.pure, analysis.zipped_data, cipher=block_cipher)
+exe = EXE(
+    pyz,
+    analysis.scripts,
+    analysis.binaries,
+    analysis.zipfiles,
+    analysis.datas,
+    [],
+    name="stream_to_youtube",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)


### PR DESCRIPTION
## Summary
- add a Windows offline build kit with documentation, PyInstaller spec, requirements, and helper scripts
- reference the offline kit from the existing primary Windows documentation
- update .gitignore to ignore build artifacts while keeping the kit files tracked

## Testing
- not run (not needed)


------
https://chatgpt.com/codex/tasks/task_e_68e1eedc3d88832281b22083240ba274