### PR TITLE
Update Windows documentation paths to myapps location

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,9 +12,9 @@ Two-module setup:
 
 - 📘 Consulte o [guia completo de instalação no Windows](primary-windows-instalacao.md#2-executável-distribuído) para seguir o fluxo recomendado com o executável distribuído.
 
-1. Posicione `stream_to_youtube.exe` em `C:\bwb\apps\YouTube\` e mantenha o FFmpeg em `C:\bwb\ffmpeg\bin\ffmpeg.exe`.
+1. Posicione `stream_to_youtube.exe` em `C:\myapps\` e mantenha o FFmpeg em `C:\myapps\ffmpeg\bin\ffmpeg.exe`.
 2. Crie um `.env` ao lado do executável com `YT_KEY=<CHAVE_DO_STREAM>` (e, se necessário, `YT_URL` ou um caminho alternativo para `FFMPEG`).
-3. Rode `stream_to_youtube.exe` a partir desse diretório e verifique os logs em `C:\bwb\apps\YouTube\logs\bwb_services.log`.
+3. Rode `stream_to_youtube.exe` a partir desse diretório e verifique os logs em `C:\myapps\logs\bwb_services.log`.
 4. (Opcional) Para manutenção via código-fonte ou geração de novos builds, siga as seções 3 e 4 do mesmo guia.
 
 ### Secondary (Droplet)

--- a/docs/primary-windows-instalacao.md
+++ b/docs/primary-windows-instalacao.md
@@ -1,16 +1,16 @@
 # Guia de instalação do módulo primário (Windows)
 
-Este guia explica como preparar um host Windows para executar o módulo **primary-windows**, priorizando o uso do executável distribuído (`C:\bwb\apps\YouTube\stream_to_youtube.exe`) e mantendo a execução via código-fonte como alternativa de manutenção.
+Este guia explica como preparar um host Windows para executar o módulo **primary-windows**, priorizando o uso do executável distribuído (`C:\myapps\stream_to_youtube.exe`) e mantendo a execução via código-fonte como alternativa de manutenção.
 
 ## 1. Preparação do host Windows
 
-1. **Organize as pastas padrão da BWB**:
-   - Crie `C:\bwb\apps\YouTube\` para armazenar o executável e arquivos auxiliares.
+1. **Organize o diretório padrão da aplicação**:
+   - Crie `C:\myapps\` para armazenar o executável e arquivos auxiliares.
    - Garanta permissão de escrita para o usuário que operará o serviço (necessário para criação de logs).
 2. **Instale o FFmpeg e configure o caminho padrão**:
-   - Crie a pasta `C:\bwb\ffmpeg\bin\`.
+   - Crie a pasta `C:\myapps\ffmpeg\bin\`.
    - Copie ou extraia `ffmpeg.exe` (e os demais binários do pacote FFmpeg) para esse diretório.
-   - O módulo procura o executável em `C:\bwb\ffmpeg\bin\ffmpeg.exe` através da variável `FFMPEG`; se preferir outro local, ajuste essa variável no `.env`.
+   - O módulo procura o executável em `C:\myapps\ffmpeg\bin\ffmpeg.exe` através da variável `FFMPEG`; se preferir outro local, ajuste essa variável no `.env`.
 3. **(Opcional) Prepare o ambiente de desenvolvimento**:
    - Instale o Python 3.11 caso seja necessário executar diretamente a partir do código-fonte ou gerar novos builds com o PyInstaller.
    - Obtenha o repositório `bwb-stream2yt` (via Git ou ZIP) somente se for atuar nessa modalidade.
@@ -43,19 +43,19 @@ Escolha uma das opções abaixo para copiar o conteúdo do repositório para o s
 
 ## 2. Executável distribuído
 
-1. **Posicione o binário oficial** em `C:\bwb\apps\YouTube\stream_to_youtube.exe`.
+1. **Posicione o binário oficial** em `C:\myapps\stream_to_youtube.exe`.
 2. **Ajuste o arquivo de configuração**:
    - Ao executar o binário pela primeira vez, o script cria automaticamente um `.env` no mesmo diretório usando o template padrão.
    - Em seguida, edite o `.env` recém-criado e configure ao menos `YT_KEY=<CHAVE_DO_STREAM>` (ou `YT_URL` completo, se preferir).
    - Ajuste `YT_INPUT_ARGS`, `YT_OUTPUT_ARGS`, as credenciais RTSP e `FFMPEG` conforme a necessidade do equipamento local.
 3. **Instale e opere o serviço**:
-   - Abra um *Prompt de Comando* com privilégios administrativos e navegue até `C:\bwb\apps\YouTube\`.
+   - Abra um *Prompt de Comando* com privilégios administrativos e navegue até `C:\myapps\`.
    - Instale ou atualize o serviço com `stream_to_youtube.exe /service`.
    - Inicie e interrompa a execução conforme necessário com `stream_to_youtube.exe /start` e `stream_to_youtube.exe /stop`.
    - Remova o serviço com `stream_to_youtube.exe /noservice` quando não for mais necessário.
    - O `.env` será carregado automaticamente durante a inicialização do executável (seja via serviço ou execução direta).
 4. **Verifique os logs**:
-   - Os registros são gravados em arquivos diários `C:\bwb\apps\YouTube\logs\bwb_services-YYYY-MM-DD.log` (a pasta `logs\` é criada se necessário e mantemos somente os últimos sete dias).
+   - Os registros são gravados em arquivos diários `C:\myapps\logs\bwb_services-YYYY-MM-DD.log` (a pasta `logs\` é criada se necessário e mantemos somente os últimos sete dias).
    - Utilize esses arquivos para confirmar a inicialização do FFmpeg e eventuais erros de autenticação.
 5. **Homologação rápida**:
    - Confirme, durante o primeiro teste, se o YouTube recebe o stream na URL primária e se o log indica status `connected`.
@@ -80,15 +80,15 @@ Para gerar o executável sem acesso à internet, utilize o kit de build localiza
 
 1. Instale o Python 3.11 e siga o passo a passo descrito no `README.md` do diretório `via-windows` (ou execute `prepare-env.bat` e `build.bat`).
 2. O spec file `stream_to_youtube.spec` encapsula os mesmos parâmetros da nossa pipeline (`--onefile`, `--noconsole`, `--hidden-import win32timezone`, `--collect-binaries pywin32`, etc.), garantindo que `pywin32` e demais dependências sejam embaladas corretamente.
-3. Ao término do processo, copie `primary-windows\via-windows\dist\stream_to_youtube.exe` para `C:\bwb\apps\YouTube\` juntamente com um `.env` atualizado.
-4. Durante a distribuição, reforce a necessidade do `ffmpeg.exe` presente em `C:\bwb\ffmpeg\bin\` ou documente o caminho alternativo via variável `FFMPEG`.
+3. Ao término do processo, copie `primary-windows\via-windows\dist\stream_to_youtube.exe` para `C:\myapps\` juntamente com um `.env` atualizado.
+4. Durante a distribuição, reforce a necessidade do `ffmpeg.exe` presente em `C:\myapps\ffmpeg\bin\` ou documente o caminho alternativo via variável `FFMPEG`.
 
 ## 5. Checklist de verificação
 
-- [ ] `stream_to_youtube.exe` posicionado em `C:\bwb\apps\YouTube\`.
+- [ ] `stream_to_youtube.exe` posicionado em `C:\myapps\`.
 - [ ] `.env` ajustado no mesmo diretório com `YT_KEY` (e, se necessário, `YT_URL`/`FFMPEG`).
-- [ ] `ffmpeg.exe` disponível em `C:\bwb\ffmpeg\bin\` ou caminho ajustado na configuração.
-- [ ] Execução do executável gera arquivos `C:\bwb\apps\YouTube\logs\bwb_services-YYYY-MM-DD.log` (com retenção automática de sete dias) sem erros críticos.
+- [ ] `ffmpeg.exe` disponível em `C:\myapps\ffmpeg\bin\` ou caminho ajustado na configuração.
+- [ ] Execução do executável gera arquivos `C:\myapps\logs\bwb_services-YYYY-MM-DD.log` (com retenção automática de sete dias) sem erros críticos.
 - [ ] Dashboard do YouTube confirma conexão do stream durante o teste.
 - [ ] (Opcional) Ambiente Python 3.11 preparado para manutenção via código-fonte ou geração de novos builds.
 

--- a/primary-windows/README.md
+++ b/primary-windows/README.md
@@ -9,8 +9,8 @@ Ferramenta oficial para enviar o feed (RTSP/DirectShow) para a URL **primária**
 
 ### Executável distribuído
 
-- Siga o [guia de instalação](../docs/primary-windows-instalacao.md#2-executável-distribuído) para posicionar o `stream_to_youtube.exe` em `C:\bwb\apps\YouTube\`. A primeira execução gera automaticamente o `.env` ao lado do binário; edite-o em seguida para informar `YT_KEY`/`YT_URL`, argumentos do FFmpeg e credenciais RTSP conforme o equipamento.
-- A execução gera arquivos diários em `C:\bwb\apps\YouTube\logs\bwb_services-YYYY-MM-DD.log` (retenção automática de sete dias). Utilize-os para homologar a conexão com o YouTube.
+- Siga o [guia de instalação](../docs/primary-windows-instalacao.md#2-executável-distribuído) para posicionar o `stream_to_youtube.exe` em `C:\myapps\`. A primeira execução gera automaticamente o `.env` ao lado do binário; edite-o em seguida para informar `YT_KEY`/`YT_URL`, argumentos do FFmpeg e credenciais RTSP conforme o equipamento.
+- A execução gera arquivos diários em `C:\myapps\logs\bwb_services-YYYY-MM-DD.log` (retenção automática de sete dias). Utilize-os para homologar a conexão com o YouTube.
 - Para instalar o serviço do Windows, execute o binário uma vez com `stream_to_youtube.exe /service`. Em seguida:
   - Inicie com `stream_to_youtube.exe /start`.
   - Interrompa com `stream_to_youtube.exe /stop`.
@@ -35,7 +35,7 @@ Ferramenta oficial para enviar o feed (RTSP/DirectShow) para a URL **primária**
 
 - `YT_DAY_START_HOUR`, `YT_DAY_END_HOUR` e `YT_TZ_OFFSET_HOURS` controlam a janela de transmissão.
 - `YT_INPUT_ARGS` / `YT_OUTPUT_ARGS` permitem ajustar os argumentos do ffmpeg.
-- `FFMPEG` aponta para o executável do ffmpeg (por omissão `C:\bwb\ffmpeg\bin\ffmpeg.exe`).
+- `FFMPEG` aponta para o executável do ffmpeg (por omissão `C:\myapps\ffmpeg\bin\ffmpeg.exe`).
 - `BWB_LOG_FILE` define o caminho base dos logs. Gravamos arquivos diários no formato
   `<nome>-YYYY-MM-DD.log` e mantemos automaticamente somente os últimos sete dias.
 

--- a/primary-windows/via-windows/README.md
+++ b/primary-windows/via-windows/README.md
@@ -6,13 +6,13 @@ These instructions describe how to package the **stream_to_youtube** Windows exe
 
 1. Windows 10 or newer with administrator privileges.
 2. Python 3.11.x from <https://www.python.org/downloads/windows/> installed for "All Users" with the "Add python.exe to PATH" option enabled.
-3. Local copy of this repository synced to `C:\bwb\src\stream2yt\` (or another working directory of your choice).
+3. Local copy of this repository synced to `C:\myapps\src\stream2yt\` (or another working directory of your choice).
    - If you still need to download the sources, follow the step-by-step guide in [docs/primary-windows-instalacao.md](../../docs/primary-windows-instalacao.md#11-obter-o-repositorio-git-ou-zip).
 
 ## 1. Prepare the virtual environment
 
 ```powershell
-cd C:\bwb\src\stream2yt\primary-windows\via-windows
+cd C:\myapps\src\stream2yt\primary-windows\via-windows
 python -m venv .venv
 .venv\Scripts\activate
 python -m pip install --upgrade pip
@@ -42,10 +42,10 @@ Alternatively, execute `build.bat` to run the same command sequence automaticall
 Copy the generated executable to the target offline location expected by the Windows primary deployment:
 
 ```powershell
-Copy-Item dist\stream_to_youtube.exe C:\bwb\apps\YouTube\stream_to_youtube.exe -Force
+Copy-Item dist\stream_to_youtube.exe C:\myapps\stream_to_youtube.exe -Force
 ```
 
-You can now distribute `C:\bwb\apps\YouTube\stream_to_youtube.exe` to operators or bundle it with the installation media.
+You can now distribute `C:\myapps\stream_to_youtube.exe` to operators or bundle it with the installation media.
 
 ## 4. Clean up (optional)
 


### PR DESCRIPTION
## Summary
- replace Windows deployment documentation references from C:\bwb to the new C:\myapps structure
- refresh installation, service, logging, and build instructions to keep examples consistent across guides

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e1f29a1aac8322aa639f1d2493c9e6