### PR TITLE
Update Windows docs to reference new FFmpeg path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -12,8 +12,8 @@ Two-module setup:
 
 - 📘 Consulte o [guia completo de instalação no Windows](primary-windows-instalacao.md#2-executável-distribuído) para seguir o fluxo recomendado com o executável distribuído.
 
-1. Posicione `stream_to_youtube.exe` em `C:\myapps\` e mantenha o FFmpeg em `C:\myapps\ffmpeg\bin\ffmpeg.exe`.
-2. Crie um `.env` ao lado do executável com `YT_KEY=<CHAVE_DO_STREAM>` (e, se necessário, `YT_URL` ou um caminho alternativo para `FFMPEG`).
+1. Posicione `stream_to_youtube.exe` em `C:\myapps\` e mantenha o FFmpeg em `C:\bwb\ffmpeg\bin\ffmpeg.exe`.
+2. Crie um `.env` ao lado do executável com `YT_KEY=<CHAVE_DO_STREAM>` (e, se necessário, `YT_URL` ou um caminho alternativo para `FFMPEG`; para usar outro diretório basta sobrescrever essa variável no `.env`).
 3. Rode `stream_to_youtube.exe` a partir desse diretório e verifique os logs em `C:\myapps\logs\bwb_services.log`.
 4. (Opcional) Para manutenção via código-fonte ou geração de novos builds, siga as seções 3 e 4 do mesmo guia.
 

--- a/docs/primary-windows-instalacao.md
+++ b/docs/primary-windows-instalacao.md
@@ -8,9 +8,9 @@ Este guia explica como preparar um host Windows para executar o módulo **primar
    - Crie `C:\myapps\` para armazenar o executável e arquivos auxiliares.
    - Garanta permissão de escrita para o usuário que operará o serviço (necessário para criação de logs).
 2. **Instale o FFmpeg e configure o caminho padrão**:
-   - Crie a pasta `C:\myapps\ffmpeg\bin\`.
-   - Copie ou extraia `ffmpeg.exe` (e os demais binários do pacote FFmpeg) para esse diretório.
-   - O módulo procura o executável em `C:\myapps\ffmpeg\bin\ffmpeg.exe` através da variável `FFMPEG`; se preferir outro local, ajuste essa variável no `.env`.
+   - Crie a pasta `C:\bwb\ffmpeg\bin\` (ou adapte caso utilize um drive diferente).
+   - Copie ou extraia `ffmpeg.exe` (e os demais binários do pacote FFmpeg) para esse diretório, garantindo que o caminho final seja `C:\bwb\ffmpeg\bin\ffmpeg.exe`.
+   - O módulo utiliza esse caminho por padrão através da variável `FFMPEG`. Se preferir outro local, sobrescreva `FFMPEG` no `.env` posicionado ao lado do executável ou no diretório `primary-windows\src\` (para execuções via código-fonte).
 3. **(Opcional) Prepare o ambiente de desenvolvimento**:
    - Instale o Python 3.11 caso seja necessário executar diretamente a partir do código-fonte ou gerar novos builds com o PyInstaller.
    - Obtenha o repositório `bwb-stream2yt` (via Git ou ZIP) somente se for atuar nessa modalidade.
@@ -81,13 +81,13 @@ Para gerar o executável sem acesso à internet, utilize o kit de build localiza
 1. Instale o Python 3.11 e siga o passo a passo descrito no `README.md` do diretório `via-windows` (ou execute `prepare-env.bat` e `build.bat`).
 2. O spec file `stream_to_youtube.spec` encapsula os mesmos parâmetros da nossa pipeline (`--onefile`, `--noconsole`, `--hidden-import win32timezone`, `--collect-binaries pywin32`, etc.), garantindo que `pywin32` e demais dependências sejam embaladas corretamente.
 3. Ao término do processo, copie `primary-windows\via-windows\dist\stream_to_youtube.exe` para `C:\myapps\` juntamente com um `.env` atualizado.
-4. Durante a distribuição, reforce a necessidade do `ffmpeg.exe` presente em `C:\myapps\ffmpeg\bin\` ou documente o caminho alternativo via variável `FFMPEG`.
+4. Durante a distribuição, reforce a necessidade do `ffmpeg.exe` presente em `C:\bwb\ffmpeg\bin\` ou documente o caminho alternativo via variável `FFMPEG` (caso a equipe opte por outro diretório, basta sobrescrever o valor no `.env`).
 
 ## 5. Checklist de verificação
 
 - [ ] `stream_to_youtube.exe` posicionado em `C:\myapps\`.
 - [ ] `.env` ajustado no mesmo diretório com `YT_KEY` (e, se necessário, `YT_URL`/`FFMPEG`).
-- [ ] `ffmpeg.exe` disponível em `C:\myapps\ffmpeg\bin\` ou caminho ajustado na configuração.
+- [ ] `ffmpeg.exe` disponível em `C:\bwb\ffmpeg\bin\` ou caminho ajustado na configuração.
 - [ ] Execução do executável gera arquivos `C:\myapps\logs\bwb_services-YYYY-MM-DD.log` (com retenção automática de sete dias) sem erros críticos.
 - [ ] Dashboard do YouTube confirma conexão do stream durante o teste.
 - [ ] (Opcional) Ambiente Python 3.11 preparado para manutenção via código-fonte ou geração de novos builds.

--- a/primary-windows/README.md
+++ b/primary-windows/README.md
@@ -9,7 +9,7 @@ Ferramenta oficial para enviar o feed (RTSP/DirectShow) para a URL **primária**
 
 ### Executável distribuído
 
-- Siga o [guia de instalação](../docs/primary-windows-instalacao.md#2-executável-distribuído) para posicionar o `stream_to_youtube.exe` em `C:\myapps\`. A primeira execução gera automaticamente o `.env` ao lado do binário; edite-o em seguida para informar `YT_KEY`/`YT_URL`, argumentos do FFmpeg e credenciais RTSP conforme o equipamento.
+- Siga o [guia de instalação](../docs/primary-windows-instalacao.md#2-executável-distribuído) para posicionar o `stream_to_youtube.exe` em `C:\myapps\`. A primeira execução gera automaticamente o `.env` ao lado do binário; edite-o em seguida para informar `YT_KEY`/`YT_URL`, argumentos do FFmpeg e credenciais RTSP conforme o equipamento (o valor padrão de `FFMPEG` aponta para `C:\bwb\ffmpeg\bin\ffmpeg.exe`, mas é possível sobrescrevê-lo nesse arquivo se desejar outro diretório).
 - A execução gera arquivos diários em `C:\myapps\logs\bwb_services-YYYY-MM-DD.log` (retenção automática de sete dias). Utilize-os para homologar a conexão com o YouTube.
 - Para instalar o serviço do Windows, execute o binário uma vez com `stream_to_youtube.exe /service`. Em seguida:
   - Inicie com `stream_to_youtube.exe /start`.
@@ -35,7 +35,7 @@ Ferramenta oficial para enviar o feed (RTSP/DirectShow) para a URL **primária**
 
 - `YT_DAY_START_HOUR`, `YT_DAY_END_HOUR` e `YT_TZ_OFFSET_HOURS` controlam a janela de transmissão.
 - `YT_INPUT_ARGS` / `YT_OUTPUT_ARGS` permitem ajustar os argumentos do ffmpeg.
-- `FFMPEG` aponta para o executável do ffmpeg (por omissão `C:\myapps\ffmpeg\bin\ffmpeg.exe`).
+- `FFMPEG` aponta para o executável do ffmpeg (por omissão `C:\bwb\ffmpeg\bin\ffmpeg.exe`; defina outro caminho no `.env` se preferir).
 - `BWB_LOG_FILE` define o caminho base dos logs. Gravamos arquivos diários no formato
   `<nome>-YYYY-MM-DD.log` e mantemos automaticamente somente os últimos sete dias.
 


### PR DESCRIPTION
## Summary
- update the Windows installation guide to use `C:\bwb\ffmpeg\bin\ffmpeg.exe` and explain how to override it in `.env`
- align the quick start documentation so the default FFmpeg path matches the new location
- clarify that operators can change the `FFMPEG` path in `.env` when needed

## Testing
- not run (documentation updates only)


------
https://chatgpt.com/codex/tasks/task_e_68e1f880cd848322ab7d6d0604892626