### PR TITLE
Bump pyinstaller hooks dependency for Windows build

### DIFF
--- a/primary-windows/via-windows/requirements.txt
+++ b/primary-windows/via-windows/requirements.txt
@@ -1,6 +1,6 @@
 # Windows-specific build dependencies for reproducing the stream_to_youtube.exe binary
 pyinstaller==6.10.0
-pyinstaller-hooks-contrib==2024.7
+pyinstaller-hooks-contrib==2024.8
 pywin32==306
 pywin32-ctypes==0.2.2
 pefile==2023.2.7


### PR DESCRIPTION
## Summary
- update the Windows requirements pin for pyinstaller-hooks-contrib to a release compatible with PyInstaller 6.10.0

## Testing
- not run (Windows-only environment script)


------
https://chatgpt.com/codex/tasks/task_e_68e201ef64288322ad15b26fc3dd830f