### PR TITLE
Handle missing __file__ in Windows spec

### DIFF
--- a/primary-windows/via-windows/stream_to_youtube.spec
+++ b/primary-windows/via-windows/stream_to_youtube.spec
@@ -6,13 +6,21 @@ pyinstaller --onefile --noconsole --hidden-import win32timezone --collect-binari
     primary-windows/src/stream_to_youtube.py
 """
 
+import inspect
 from pathlib import Path
 
 from PyInstaller.utils.hooks import collect_all
 
 block_cipher = None
 
-BASE_DIR = Path(__file__).resolve().parent
+if "__file__" in globals():
+    BASE_DIR = Path(__file__).resolve().parent
+else:
+    current_frame = inspect.currentframe()
+    try:
+        BASE_DIR = Path(inspect.getfile(current_frame)).resolve().parent
+    finally:
+        del current_frame
 SRC_DIR = (BASE_DIR / ".." / "src").resolve()
 SCRIPT = SRC_DIR / "stream_to_youtube.py"
 


### PR DESCRIPTION
## Summary
- resolve the spec directory when `__file__` is unavailable by falling back to `inspect`

## Testing
- `pyinstaller stream_to_youtube.spec` *(fails: missing Windows-only dependencies such as win32timezone in the Linux CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e203e0045083229720ea76cc383082