### PR TITLE
Report service running status after worker start

### DIFF
--- a/primary-windows/src/windows_service.py
+++ b/primary-windows/src/windows_service.py
@@ -41,6 +41,7 @@ if win32serviceutil is not None:  # pragma: no branch - platform specific
             self._worker = StreamingWorker()
             try:
                 self._worker.start()
+                self.ReportServiceStatus(win32service.SERVICE_RUNNING)
                 win32event.WaitForSingleObject(self._stop_event, win32event.INFINITE)
             except Exception as exc:  # noqa: BLE001 - must log and continue shutdown
                 log_event("service", f"Falha inesperada no serviço: {exc}")


### PR DESCRIPTION
## Summary
- report SERVICE_RUNNING to the Service Control Manager as soon as the worker thread starts in `StreamToYouTubeService.SvcDoRun`

## Testing
- not run (Windows-only service code)

------
https://chatgpt.com/codex/tasks/task_e_68e21065f4088322ab687617b8389526