### PR TITLE
Atualiza documentação do primary Windows para fluxo start/stop

### DIFF
--- a/docs/primary-windows-instalacao.md
+++ b/docs/primary-windows-instalacao.md
@@ -49,9 +49,10 @@ Escolha uma das opções abaixo para copiar o conteúdo do repositório para o s
    - Em seguida, edite o `.env` recém-criado e configure ao menos `YT_KEY=<CHAVE_DO_STREAM>` (ou `YT_URL` completo, se preferir).
    - Ajuste `YT_INPUT_ARGS`, `YT_OUTPUT_ARGS`, as credenciais RTSP e `FFMPEG` conforme a necessidade do equipamento local.
 3. **Controle da execução**:
-   - Execute `stream_to_youtube.exe` diretamente (duplo clique ou sem argumentos) para iniciar o worker. O script cria `stream_to_youtube.pid` ao lado do binário e impede inicializações duplicadas.
-   - Para interromper com segurança, abra um *Prompt de Comando* em `C:\myapps\` e execute `stream_to_youtube.exe /stop`. O comando localiza o PID registrado, envia o sinal de parada e remove o arquivo de controle ao finalizar.
-   - Em caso de desligamentos inesperados, basta executar novamente; o script limpa automaticamente registros obsoletos.
+   - O fluxo é direto, sem criação de serviço do Windows: execute `stream_to_youtube.exe /start` (ou apenas `stream_to_youtube.exe`) para iniciar o worker em segundo plano.
+   - O binário grava `stream_to_youtube.pid` com o PID ativo e utiliza a sentinela `stream_to_youtube.stop` para registrar pedidos de parada; ambos ficam na mesma pasta do executável.
+   - Para interromper com segurança, abra um *Prompt de Comando* em `C:\myapps\` e execute `stream_to_youtube.exe /stop`. O comando localiza o PID registrado, gera a sentinela e remove os arquivos de controle assim que o worker encerra.
+   - Em caso de desligamentos inesperados, basta executar novamente; o script elimina automaticamente registros obsoletos antes de reiniciar.
 4. **Verifique os logs**:
    - Os registros são gravados em arquivos diários `C:\myapps\logs\bwb_services-YYYY-MM-DD.log` (a pasta `logs\` é criada se necessário e mantemos somente os últimos sete dias).
    - Utilize esses arquivos para confirmar a inicialização do FFmpeg e eventuais erros de autenticação.

--- a/primary-windows/README.md
+++ b/primary-windows/README.md
@@ -15,7 +15,7 @@ Ferramenta oficial para enviar o feed (RTSP/DirectShow) para a URL **primária**
 
 - Siga o [guia de instalação](../docs/primary-windows-instalacao.md#2-executável-distribuído) para posicionar o `stream_to_youtube.exe` em `C:\myapps\`. A primeira execução gera automaticamente o `.env` ao lado do binário; edite-o em seguida para informar `YT_KEY`/`YT_URL`, argumentos do FFmpeg e credenciais RTSP conforme o equipamento (o valor padrão de `FFMPEG` aponta para `C:\bwb\ffmpeg\bin\ffmpeg.exe`, mas é possível sobrescrevê-lo nesse arquivo se desejar outro diretório).
 - A execução gera arquivos diários em `C:\myapps\logs\bwb_services-YYYY-MM-DD.log` (retenção automática de sete dias). Utilize-os para homologar a conexão com o YouTube.
-- O executável mantém um arquivo `stream_to_youtube.pid` ao lado do binário para garantir execução única. Utilize `stream_to_youtube.exe /stop` para encerrar a instância em segundo plano; novas execuções (inclusive duplo clique) reutilizam o mesmo fluxo de inicialização e falham com mensagem caso já haja um processo ativo.
+- O controle é feito diretamente via flags: execute `stream_to_youtube.exe /start` (ou apenas `stream_to_youtube.exe`) para iniciar o worker e `stream_to_youtube.exe /stop` para interromper. O aplicativo mantém `stream_to_youtube.pid` com o PID ativo e usa a sentinela `stream_to_youtube.stop` para sinalizar a parada; ambos ficam no mesmo diretório do executável.
 
 ### Código-fonte (desenvolvimento)
 


### PR DESCRIPTION
## Summary
- documenta o uso das flags /start e /stop no executável distribuído
- descreve os arquivos de PID e sentinela utilizados para controlar o worker

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e26fa51b88832289fa0babd9fb16f2