### PR TITLE
Documentar recuperação automática do StreamingWorker

### DIFF
--- a/docs/primary-windows-instalacao.md
+++ b/docs/primary-windows-instalacao.md
@@ -56,6 +56,7 @@ Escolha uma das opções abaixo para copiar o conteúdo do repositório para o s
 4. **Verifique os logs**:
    - Os registros são gravados em arquivos diários `C:\myapps\logs\bwb_services-YYYY-MM-DD.log` (a pasta `logs\` é criada se necessário e mantemos somente os últimos sete dias).
    - Utilize esses arquivos para confirmar a inicialização do FFmpeg e eventuais erros de autenticação.
+   - Enquanto o RTSP estiver instável, o log pode exibir mensagens como `ffmpeg exited with code ...; retrying in 5s`. Isso indica que o `StreamingWorker` está reiniciando o FFmpeg automaticamente para restabelecer a ingestão; intervenha manualmente apenas se aparecer erro ao iniciar o binário ou se a rotina de tentativa não voltar a conectar após um período prolongado.
 5. **Homologação rápida**:
    - Confirme, durante o primeiro teste, se o YouTube recebe o stream na URL primária e se o log indica status `connected`.
 


### PR DESCRIPTION
## Summary
- destacar no runbook de instalação do primary-windows que mensagens do tipo `ffmpeg exited with code ...; retrying in 5s` indicam a rotina de recuperação automática do StreamingWorker
- orientar a equipe a só intervir manualmente se o FFmpeg não iniciar ou se o loop deixar de reconectar por tempo prolongado

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2a7be89dc832289e2d4aebe36cf77