### PR TITLE
Simplify RTSP configuration when using default input args

### DIFF
--- a/docs/primary-windows-instalacao.md
+++ b/docs/primary-windows-instalacao.md
@@ -47,7 +47,7 @@ Escolha uma das opções abaixo para copiar o conteúdo do repositório para o s
 2. **Ajuste o arquivo de configuração**:
    - Ao executar o binário pela primeira vez, o script cria automaticamente um `.env` no mesmo diretório usando o template padrão.
    - Em seguida, edite o `.env` recém-criado e configure ao menos `YT_KEY=<CHAVE_DO_STREAM>` (ou `YT_URL` completo, se preferir).
-   - Ajuste `YT_INPUT_ARGS`, `YT_OUTPUT_ARGS`, as credenciais RTSP e `FFMPEG` conforme a necessidade do equipamento local.
+   - Para configurar o RTSP mais rapidamente, deixe `YT_INPUT_ARGS` em branco e informe `RTSP_HOST`, `RTSP_PORT`, `RTSP_PATH` e, se necessário, `RTSP_USERNAME`/`RTSP_PASSWORD`; o script monta a URL automaticamente com base nesses campos. Caso precise de ajustes avançados, continue podendo preencher `YT_INPUT_ARGS` manualmente (que tem precedência total), além de `YT_OUTPUT_ARGS` e `FFMPEG` conforme a necessidade do equipamento local.
 3. **Controle da execução**:
    - O fluxo é direto, sem criação de serviço do Windows: execute `stream_to_youtube.exe /start` (ou apenas `stream_to_youtube.exe`) para iniciar o worker em segundo plano.
    - O binário grava `stream_to_youtube.pid` com o PID ativo e utiliza a sentinela `stream_to_youtube.stop` para registrar pedidos de parada; ambos ficam na mesma pasta do executável.
@@ -67,7 +67,7 @@ Escolha uma das opções abaixo para copiar o conteúdo do repositório para o s
    - Repositório `bwb-stream2yt` disponível localmente (clone ou pacote ZIP extraído).
 2. **Configuração do `.env`**:
    - A primeira execução de `python stream_to_youtube.py` cria automaticamente `primary-windows\src\.env` com o template padrão.
-   - Edite o arquivo para preencher `YT_KEY` (ou `YT_URL`) e personalize os parâmetros `YT_INPUT_ARGS`, `YT_OUTPUT_ARGS`, credenciais RTSP e `FFMPEG` conforme necessário.
+   - Edite o arquivo para preencher `YT_KEY` (ou `YT_URL`). Se preferir a configuração simplificada, deixe `YT_INPUT_ARGS` em branco e defina `RTSP_HOST`, `RTSP_PORT`, `RTSP_PATH` e, opcionalmente, `RTSP_USERNAME`/`RTSP_PASSWORD`; o script gera o endereço RTSP com base nessas variáveis. Para personalizações completas, continue podendo especificar manualmente `YT_INPUT_ARGS`, `YT_OUTPUT_ARGS` e `FFMPEG`.
 3. **Execução**:
    - Abra um *Prompt de Comando* em `primary-windows\src\` e execute `python stream_to_youtube.py`.
    - O log compartilhado é gravado em arquivos diários `primary-windows\src\logs\bwb_services-YYYY-MM-DD.log` com retenção automática de sete dias.

--- a/primary-windows/README.md
+++ b/primary-windows/README.md
@@ -13,7 +13,7 @@ Ferramenta oficial para enviar o feed (RTSP/DirectShow) para a URL **primária**
 
 ### Executável distribuído
 
-- Siga o [guia de instalação](../docs/primary-windows-instalacao.md#2-executável-distribuído) para posicionar o `stream_to_youtube.exe` em `C:\myapps\`. A primeira execução gera automaticamente o `.env` ao lado do binário; edite-o em seguida para informar `YT_KEY`/`YT_URL`, argumentos do FFmpeg e credenciais RTSP conforme o equipamento (o valor padrão de `FFMPEG` aponta para `C:\bwb\ffmpeg\bin\ffmpeg.exe`, mas é possível sobrescrevê-lo nesse arquivo se desejar outro diretório).
+- Siga o [guia de instalação](../docs/primary-windows-instalacao.md#2-executável-distribuído) para posicionar o `stream_to_youtube.exe` em `C:\myapps\`. A primeira execução gera automaticamente o `.env` ao lado do binário; edite-o em seguida para informar `YT_KEY`/`YT_URL`. Caso deixe `YT_INPUT_ARGS` em branco, basta preencher `RTSP_HOST`/`RTSP_PORT`/`RTSP_PATH` (e, se necessário, `RTSP_USERNAME`/`RTSP_PASSWORD`) para que o script monte o endereço RTSP automaticamente. O valor padrão de `FFMPEG` aponta para `C:\bwb\ffmpeg\bin\ffmpeg.exe`, mas é possível sobrescrevê-lo nesse arquivo se desejar outro diretório.
 - A execução gera arquivos diários em `C:\myapps\logs\bwb_services-YYYY-MM-DD.log` (retenção automática de sete dias). Utilize-os para homologar a conexão com o YouTube.
 - O controle é feito diretamente via flags: execute `stream_to_youtube.exe /start` (ou apenas `stream_to_youtube.exe`) para iniciar o worker e `stream_to_youtube.exe /stop` para interromper. O aplicativo mantém `stream_to_youtube.pid` com o PID ativo e usa a sentinela `stream_to_youtube.stop` para sinalizar a parada; ambos ficam no mesmo diretório do executável.
 
@@ -34,7 +34,7 @@ Ferramenta oficial para enviar o feed (RTSP/DirectShow) para a URL **primária**
 `stream_to_youtube.py` aceita overrides através de variáveis ou do `.env`:
 
 - `YT_DAY_START_HOUR`, `YT_DAY_END_HOUR` e `YT_TZ_OFFSET_HOURS` controlam a janela de transmissão.
-- `YT_INPUT_ARGS` / `YT_OUTPUT_ARGS` permitem ajustar os argumentos do ffmpeg.
+- `YT_INPUT_ARGS` / `YT_OUTPUT_ARGS` permitem ajustar os argumentos do ffmpeg. Se `YT_INPUT_ARGS` ficar vazio, o script tenta montar a URL RTSP com `RTSP_HOST`, `RTSP_PORT`, `RTSP_PATH` e, opcionalmente, `RTSP_USERNAME`/`RTSP_PASSWORD`.
 - `FFMPEG` aponta para o executável do ffmpeg (por omissão `C:\bwb\ffmpeg\bin\ffmpeg.exe`; defina outro caminho no `.env` se preferir).
 - `BWB_LOG_FILE` define o caminho base dos logs. Gravamos arquivos diários no formato
   `<nome>-YYYY-MM-DD.log` e mantemos automaticamente somente os últimos sete dias.


### PR DESCRIPTION
## Summary
- add optional RTSP environment variables to the Windows primary template and reuse them to build an RTSP URL when possible
- keep manual `YT_INPUT_ARGS` overrides intact while generating defaults from `RTSP_*` variables when the override is blank
- document the simplified RTSP configuration flow in the Windows primary README and installation guide

## Testing
- python -m compileall primary-windows/src/stream_to_youtube.py

------
https://chatgpt.com/codex/tasks/task_e_68e2abc20cdc8322ae2e2cacfa05051c