### PR TITLE
Enforce fallback activation during night cycles

### DIFF
--- a/secondary-droplet/bin/yt_decider_daemon.py
+++ b/secondary-droplet/bin/yt_decider_daemon.py
@@ -217,15 +217,15 @@ def main():
             context.primary_bad_streak = 0
         # Night: 19:00–08:00 keep fallback if no primary
         if not (DAY_START <= hour < DAY_END):
-            if primary_bad:
-                if not fallback_on:
-                    start_fallback()
-                    action = "START secondary"
-                    detail = "night + no primary"
-                else:
-                    detail = detail or ""
+            if not fallback_on:
+                start_fallback()
+                fallback_on = True
+                action = "START secondary"
+                detail = "night – force secondary on"
             else:
-                action = "KEEP"
+                detail = detail or (
+                    "night – force secondary on" if primary_ok else ""
+                )
         else:
             # Day: stop fallback if primary OK, else keep/start
             if primary_ok:

--- a/secondary-droplet/tests/test_decider.py
+++ b/secondary-droplet/tests/test_decider.py
@@ -220,7 +220,7 @@ def test_night_without_primary_starts_secondary(monkeypatch):
     assert result["stop_calls"] == 0
     fields = _extract_decision_fields(result)
     assert fields[4] == "START secondary"
-    assert fields[5] == "night + no primary"
+    assert fields[5] == "night – force secondary on"
 
 
 def test_night_with_healthy_primary_keeps_state(monkeypatch):
@@ -239,7 +239,7 @@ def test_night_with_healthy_primary_keeps_state(monkeypatch):
     assert result["stop_calls"] == 0
     fields = _extract_decision_fields(result)
     assert fields[4] == "KEEP"
-    assert fields[5] == ""
+    assert fields[5] == "night – force secondary on"
 
 
 def test_daytime_primary_needs_hysteresis(monkeypatch):

--- a/tests/test_stream_to_youtube.py
+++ b/tests/test_stream_to_youtube.py
@@ -3,6 +3,7 @@ import signal
 import sys
 import threading
 import time
+import types
 from pathlib import Path
 
 MODULE_PATH = Path(__file__).resolve().parents[1] / "primary-windows" / "src" / "stream_to_youtube.py"
@@ -10,6 +11,16 @@ SPEC = importlib.util.spec_from_file_location("_stream_to_youtube_test", MODULE_
 assert SPEC and SPEC.loader
 module = importlib.util.module_from_spec(SPEC)
 sys.modules["_stream_to_youtube_test"] = module
+
+if "autotune" not in sys.modules:
+    autotune_stub = types.ModuleType("autotune")
+
+    def _estimate_upload_bitrate(*_args, **_kwargs):
+        raise NotImplementedError
+
+    autotune_stub.estimate_upload_bitrate = _estimate_upload_bitrate  # type: ignore[attr-defined]
+    sys.modules["autotune"] = autotune_stub
+
 SPEC.loader.exec_module(module)
 
 

--- a/tests/test_yt_decider_daemon.py
+++ b/tests/test_yt_decider_daemon.py
@@ -1,0 +1,64 @@
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "secondary-droplet"
+    / "bin"
+    / "yt_decider_daemon.py"
+)
+SPEC = importlib.util.spec_from_file_location("_yt_decider_daemon_test", MODULE_PATH)
+assert SPEC and SPEC.loader
+module = importlib.util.module_from_spec(SPEC)
+sys.modules["_yt_decider_daemon_test"] = module
+SPEC.loader.exec_module(module)
+
+
+def test_night_cycle_forces_secondary_start(monkeypatch):
+    module.context.primary_ok_streak = 0
+    module.context.primary_bad_streak = 0
+
+    fallback_state = {"active": False}
+    actions: list[str] = []
+    decisions: list[dict[str, str]] = []
+
+    monkeypatch.setattr(module, "build_api", lambda: object())
+    monkeypatch.setattr(
+        module,
+        "get_state",
+        lambda yt: {"streamStatus": "active", "health": "good", "note": ""},
+    )
+    monkeypatch.setattr(module, "local_hour", lambda: 2)
+    monkeypatch.setattr(module, "log_event", lambda *args, **kwargs: None)
+
+    def fake_is_active(unit: str) -> bool:
+        assert unit == "youtube-fallback.service"
+        return fallback_state["active"]
+
+    def fake_start_fallback() -> None:
+        actions.append("start")
+        fallback_state["active"] = True
+
+    def fake_log_cycle_decision(**kwargs) -> None:
+        decisions.append(kwargs)
+
+    monkeypatch.setattr(module, "is_active", fake_is_active)
+    monkeypatch.setattr(module, "start_fallback", fake_start_fallback)
+    monkeypatch.setattr(module, "log_cycle_decision", fake_log_cycle_decision)
+
+    def raise_on_sleep(_seconds: float) -> None:
+        raise SystemExit
+
+    monkeypatch.setattr(module.time, "sleep", raise_on_sleep)
+
+    with pytest.raises(SystemExit):
+        module.main()
+
+    assert actions == ["start"]
+    assert decisions
+    assert decisions[-1]["action"] == "START secondary"
+    assert decisions[-1]["detail"] == "night – force secondary on"


### PR DESCRIPTION
## Summary
- force the YouTube fallback service on during night hours whenever it is not running, even if the primary ingest reports healthy, and update the decision detail message
- align existing decider tests with the new night-time behaviour and add a dedicated regression test for starting the secondary path during the night
- stub the optional autotune dependency so the stream_to_youtube tests can import without external modules

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e2cd895b848322b14cb03d1225bf36