### PR TITLE
Add documentation for ytc web integration

### DIFF
--- a/ytc-web/backend-service.md
+++ b/ytc-web/backend-service.md
@@ -1,0 +1,41 @@
+# Serviço backend na droplet
+
+Este guia descreve como montar um microserviço HTTP na droplet secundária que consulta a API do YouTube e expõe um endpoint com o estado do canal. O serviço **não** deve retransmitir vídeo; limita-se a autenticar, recolher metadados e devolver um JSON seguro para uso no website.
+
+## Requisitos prévios
+
+- Droplet já configurada com o token OAuth (`/root/token.json`) utilizado pelos scripts `yt_api_probe_once.py`.
+- Python 3.11 (o mesmo usado no repositório) e dependências listadas em `requirements-dev.txt` para reuso do cliente da API.
+- Acesso SSH privilegiado para configurar `systemd`, firewalls e variáveis de ambiente.
+
+## Passos de implementação
+
+1. **Criar um ambiente isolado**
+   - Crie uma pasta, por exemplo `/opt/ytc-web-service`.
+   - Configure um `virtualenv` e instale as dependências mínimas (`google-api-python-client`, `fastapi`/`uvicorn` ou `Flask`).
+
+2. **Reutilizar a lógica existente**
+   - Copie ou refatore a função que consulta `liveBroadcasts.list` e `liveStreams.list` a partir de `scripts/yt_api_probe_once.py`.
+   - Envolva a chamada numa função `fetch_live_status()` que devolve um dicionário pronto para serializar.
+
+3. **Expor um endpoint HTTP**
+   - Monte uma aplicação (ex.: FastAPI) com uma rota `GET /api/live-status` que:
+     - Lê o token OAuth do caminho definido em variável de ambiente (`YT_OAUTH_TOKEN_PATH`).
+     - Aplica cache in-memory de alguns segundos (ex.: 30s) para respeitar a quota da API.
+     - Devolve JSON conforme descrito em `status-endpoint.md`.
+
+4. **Configurar `systemd`**
+   - Crie um serviço em `/etc/systemd/system/ytc-web.service` que execute o servidor (ex.: `uvicorn app:app --host 127.0.0.1 --port 8081`).
+   - Active `systemctl enable --now ytc-web.service` e monitorize os logs com `journalctl -u ytc-web -f`.
+
+5. **Proteger o acesso**
+   - Exponha a porta apenas para o balanceador ou túnel que irá consumir o JSON.
+   - Caso seja necessário acesso público, aplique autenticação básica ou token de acesso simples via cabeçalho.
+   - Mantenha os tokens OAuth fora do repositório e com permissões restritas (`chmod 600`).
+
+## Operação e manutenção
+
+- **Monitorização**: inclua métricas básicas (tempo de resposta, contagem de erros) e alertas caso a API retorne falhas persistentes.
+- **Actualizações**: quando a especificação do endpoint mudar, sincronize com `status-endpoint.md` e notifique a equipa web.
+- **Fallback**: em caso de indisponibilidade da API, devolva um JSON com `status="unknown"` e mensagem amigável, permitindo que o front-end apresente o aviso secundário.
+

--- a/ytc-web/frontend-integration.md
+++ b/ytc-web/frontend-integration.md
@@ -1,0 +1,71 @@
+# Integração front-end
+
+Este guia apresenta recomendações para construir uma página web que consome o endpoint `live-status` e apresenta o vídeo oficial do canal via player do YouTube.
+
+## Fluxo básico
+
+1. No carregamento da página, fazer `fetch` ao endpoint (`GET /api/live-status`).
+2. Avaliar o campo `status` e decidir o que renderizar:
+   - `live`: inserir `<iframe>` com `https://www.youtube.com/embed/{videoId}?autoplay=1&rel=0`.
+   - `starting`: mostrar o player com uma sobreposição de “vai começar dentro de momentos”.
+   - `offline` ou `unknown`: esconder o iframe e apresentar a mensagem devolvida pelo backend (ex.: imagem de fundo usada na transmissão secundária).
+3. Actualizar periodicamente (ex.: a cada 60s) para detectar mudanças de estado.
+
+## Exemplo de código
+
+```html
+<div id="live-container" class="live-container">
+  <p>Carregando…</p>
+</div>
+
+<script type="module">
+async function renderLive() {
+  const container = document.getElementById('live-container');
+  try {
+    const response = await fetch('/api/live-status', { cache: 'no-store' });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const data = await response.json();
+
+    if (data.status === 'live' && data.videoId) {
+      container.innerHTML = `
+        <iframe
+          width="100%"
+          height="100%"
+          src="https://www.youtube.com/embed/${data.videoId}?autoplay=1&rel=0"
+          title="${data.title ?? 'Transmissão ao vivo'}"
+          frameborder="0"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowfullscreen
+        ></iframe>`;
+    } else {
+      container.innerHTML = `<div class="live-fallback">${data.message ?? 'Voltamos já.'}</div>`;
+    }
+  } catch (error) {
+    console.error('Falha ao consultar live-status', error);
+    container.innerHTML = '<div class="live-error">Não foi possível carregar a transmissão.</div>';
+  }
+}
+
+renderLive();
+setInterval(renderLive, 60000);
+</script>
+```
+
+## Boas práticas de UX
+
+- **Responsividade**: envolva o iframe numa `div` com proporção 16:9 usando `padding-top` ou `aspect-ratio`.
+- **Acessibilidade**: forneça texto alternativo nas mensagens de fallback e traduza conforme o público-alvo.
+- **Indicadores de estado**: considere mostrar o `data.updatedAt` formatado (“actualizado há X segundos”) para reforçar a frescura dos dados.
+
+## Considerações de segurança
+
+- Carregue o endpoint via HTTPS para evitar mistura de conteúdo.
+- Não exponha chaves ou tokens no front-end; toda a autenticação permanece na droplet.
+- Respeite as políticas de reprodução automática do navegador — alguns exigem interação do utilizador para iniciar áudio.
+
+## Extensões possíveis
+
+- Integrar o chat ao vivo com `https://www.youtube.com/live_chat?v={videoId}&embed_domain=<domínio>`.
+- Mostrar a agenda de próximas emissões usando `nextEvents` quando disponível.
+- Disparar webhooks internos quando o estado mudar para `offline` para alertar a equipa.
+

--- a/ytc-web/readme.md
+++ b/ytc-web/readme.md
@@ -1,1 +1,29 @@
-pasta com ficheiros e documentação que ajude a integrar o canal no youtube em uma pagina da web.
+# Integração Web do Canal YouTube
+
+Esta pasta documenta e reúne artefactos auxiliares para criar um "add-on" web que permite incorporar o canal e a transmissão ao vivo do YouTube num site personalizado. O objectivo é facilitar o acesso ao vídeo oficial (URL primária) diretamente no browser, preservando a arquitectura actual em que a droplet apenas trata de autenticação e automatismos, sem redistribuir o sinal.
+
+## Componentes chave
+
+- **Serviço backend** na droplet, responsável por consultar a API do YouTube com o token OAuth já existente e expor um endpoint JSON público ou autenticado.
+- **Integração front-end** que consome esse endpoint e apresenta o player embebido do YouTube com mensagens de fallback adequadas.
+- **Guias operacionais** com recomendações de segurança, deployment e manutenção.
+
+## Como navegar nesta pasta
+
+| Ficheiro | Conteúdo |
+| --- | --- |
+| `backend-service.md` | Passos para levantar um microserviço HTTP na droplet que expõe o estado do canal.
+| `status-endpoint.md` | Contrato de dados do endpoint JSON (campos, exemplos e caching recomendado).
+| `frontend-integration.md` | Boas práticas para embutir o player do YouTube e lidar com diferentes estados do stream.
+
+## Workflow sugerido
+
+1. **Preparar o backend** seguindo `backend-service.md`, garantindo que o endpoint consulta `liveBroadcasts`/`liveStreams` e respeita as quotas.
+2. **Validar o contrato** comparando a resposta real com o documento `status-endpoint.md` e ajustando conforme necessário.
+3. **Implementar o site** com base nas orientações de `frontend-integration.md`, mantendo o tráfego de vídeo sempre através do YouTube.
+
+## Manutenção
+
+- Actualize esta pasta sempre que novos requisitos web surgirem (ex.: chat ao vivo, agenda de eventos).
+- Registe alterações relevantes no repositório e comunique à equipa de operações para alinhamento com as dependências existentes.
+

--- a/ytc-web/status-endpoint.md
+++ b/ytc-web/status-endpoint.md
@@ -1,0 +1,56 @@
+# Contrato do endpoint `/api/live-status`
+
+Este documento define o formato recomendado para o endpoint JSON exposto pela droplet. O objectivo é fornecer ao front-end dados suficientes para decidir se deve mostrar o player da transmissão principal, o aviso secundário ou outra informação complementar.
+
+## Estrutura da resposta
+
+```json
+{
+  "status": "live",
+  "videoId": "<ID do vídeo YouTube>",
+  "title": "Nome do programa ou transmissão",
+  "scheduledStartTime": "2024-01-30T19:00:00Z",
+  "actualStartTime": "2024-01-30T19:05:12Z",
+  "health": {
+    "streamStatus": "active",
+    "healthStatus": "good"
+  },
+  "updatedAt": "2024-01-30T19:06:00Z",
+  "message": "Estamos ao vivo!"
+}
+```
+
+### Campos obrigatórios
+
+- `status`: estado agregado do canal. Valores sugeridos:
+  - `live` — transmissão ao vivo confirmada.
+  - `starting` — broadcast encontrado em `testing` ou `ready`.
+  - `offline` — nenhum broadcast activo; mostrar última emissão ou aviso padrão.
+  - `unknown` — erro na API ou dados indisponíveis.
+- `updatedAt`: timestamp ISO8601 do momento em que a API foi consultada.
+
+### Campos opcionais
+
+- `videoId`: presente quando `status` for `live` ou `starting`.
+- `title`, `scheduledStartTime`, `actualStartTime`: metadados obtidos de `liveBroadcasts.list`.
+- `health`: resumo de `streamStatus` e `healthStatus` devolvidos por `liveStreams.list`.
+- `message`: texto amigável para ser exibido no site (ex.: “Voltamos já” quando `status=offline`).
+
+## Regras de caching
+
+- **Cache interno**: mínimo 30 segundos para evitar exceder quotas da API YouTube.
+- **Cache HTTP**: permitir `Cache-Control: public, max-age=10` para reduzir carga na droplet, mantendo actualizações quase em tempo real.
+- **Etag opcional**: pode facilitar invalidação quando o `updatedAt` muda.
+
+## Tratamento de erros
+
+- Em falha temporária da API, devolver `status="unknown"` e `message` apropriada.
+- Registar (logar) o `error.code` e `error.message` recebidos, sem repassar detalhes sensíveis para o cliente.
+- Evitar devolver stack traces ou dados internos.
+
+## Extensões futuras
+
+- `nextEvents`: lista com próximas transmissões agendadas.
+- `chatEmbedUrl`: link para incorporar o chat ao vivo, quando aplicável.
+- `analytics`: contadores agregados não sensíveis (ex.: espectadores simultâneos), se a quota permitir.
+


### PR DESCRIPTION
## Summary
- expand the ytc-web README with the goals and workflow for the website add-on
- add dedicated guides for the droplet backend service, endpoint contract, and front-end embedding

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e2cfaa4c908322831cc632f40fa6f6