### PR TITLE
Add FastAPI backend deployment automation for live status

### DIFF
--- a/scripts/post_deploy.sh
+++ b/scripts/post_deploy.sh
@@ -53,3 +53,12 @@ systemctl restart youtube-fallback.service || true
 
 # Mantemos token.json intacto; /etc/youtube-fallback.env é regenerado preservando YT_KEY.
 echo "[post_deploy] youtube-fallback atualizado e env sincronizado."
+
+echo "[post_deploy] Configurando ytc-web-backend..."
+bin/ytc_web_backend_setup.sh
+
+systemctl daemon-reload
+systemctl enable --now ytc-web-backend.service
+systemctl restart ytc-web-backend.service || true
+
+echo "[post_deploy] ytc-web-backend implantado e serviço reiniciado."

--- a/secondary-droplet/bin/ytc_web_backend_setup.sh
+++ b/secondary-droplet/bin/ytc_web_backend_setup.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+log() {
+  printf '[ytc-web-backend-setup] %s\n' "$*"
+}
+
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PROJECT_ROOT="${SCRIPT_DIR%/bin}"
+APP_SRC="${PROJECT_ROOT}/ytc-web-backend"
+INSTALL_DIR="/opt/ytc-web-service"
+VENV_DIR="${INSTALL_DIR}/venv"
+SYSTEMD_SRC="${PROJECT_ROOT}/systemd/ytc-web-backend.service"
+SYSTEMD_DEST="/etc/systemd/system/ytc-web-backend.service"
+ENV_FILE="/etc/ytc-web-backend.env"
+
+log "Preparando diretório da aplicação em ${INSTALL_DIR}"
+install -d -m 755 -o root -g root "${INSTALL_DIR}"
+
+if [ ! -d "${VENV_DIR}" ]; then
+  log "Criando virtualenv em ${VENV_DIR}"
+  python3 -m venv "${VENV_DIR}"
+fi
+
+log "Actualizando pip e instalando dependências"
+"${VENV_DIR}/bin/pip" install --upgrade pip
+"${VENV_DIR}/bin/pip" install -r "${PROJECT_ROOT}/requirements.txt"
+"${VENV_DIR}/bin/pip" install -r "${APP_SRC}/requirements.txt"
+
+log "Sincronizando código da aplicação"
+rsync -a --delete "${APP_SRC}/" "${INSTALL_DIR}/"
+
+log "Instalando unit file em ${SYSTEMD_DEST}"
+install -m 644 -o root -g root "${SYSTEMD_SRC}" "${SYSTEMD_DEST}"
+
+if [ ! -f "${ENV_FILE}" ]; then
+  log "Criando arquivo de ambiente ${ENV_FILE}"
+  tmp_env=$(mktemp)
+  {
+    echo "# /etc/ytc-web-backend.env (gerido por ytc_web_backend_setup.sh)"
+    echo "YT_OAUTH_TOKEN_PATH=${YT_OAUTH_TOKEN_PATH:-/root/token.json}"
+    echo "YTC_WEB_BACKEND_CACHE_TTL_SECONDS=${YTC_WEB_BACKEND_CACHE_TTL_SECONDS:-30}"
+  } > "${tmp_env}"
+  install -m 600 -o root -g root "${tmp_env}" "${ENV_FILE}"
+  rm -f "${tmp_env}"
+else
+  chmod 600 "${ENV_FILE}"
+fi
+
+log "Configuração do backend web concluída."

--- a/secondary-droplet/systemd/ytc-web-backend.service
+++ b/secondary-droplet/systemd/ytc-web-backend.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=YTC Web Backend (FastAPI)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+User=root
+Group=root
+EnvironmentFile=/etc/ytc-web-backend.env
+WorkingDirectory=/opt/ytc-web-service
+ExecStart=/opt/ytc-web-service/venv/bin/uvicorn app:app --host 127.0.0.1 --port 8081
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=30
+
+[Install]
+WantedBy=multi-user.target

--- a/secondary-droplet/ytc-web-backend/app.py
+++ b/secondary-droplet/ytc-web-backend/app.py
@@ -1,0 +1,163 @@
+"""FastAPI app exposing the /api/live-status endpoint for the secondary droplet.
+
+This module reuses the logic from the legacy yt_api_probe_once.py helper to query
+YouTube's LiveBroadcasts and LiveStreams API endpoints, applying an in-memory cache
+to respect API quotas.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, Optional
+
+from fastapi import FastAPI, HTTPException
+from google.oauth2.credentials import Credentials
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+SCOPES = [
+    "https://www.googleapis.com/auth/youtube.readonly",
+    "https://www.googleapis.com/auth/youtube",
+]
+DEFAULT_CACHE_TTL = 30
+
+app = FastAPI(title="YTC Web Backend", version="1.0.0")
+
+_logger = logging.getLogger("ytc-web-backend")
+if not _logger.handlers:
+    logging.basicConfig(level=logging.INFO)
+
+_cache_lock = threading.Lock()
+_cache: Dict[str, Any] = {"expires_at": None, "value": None}
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _isoformat(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _token_path() -> str:
+    token_path = os.getenv("YT_OAUTH_TOKEN_PATH")
+    if not token_path:
+        raise RuntimeError("YT_OAUTH_TOKEN_PATH não definido nas variáveis de ambiente.")
+    return token_path
+
+
+def _cache_ttl_seconds() -> int:
+    raw = os.getenv("YTC_WEB_BACKEND_CACHE_TTL_SECONDS", str(DEFAULT_CACHE_TTL))
+    try:
+        value = int(raw)
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise RuntimeError("Valor inválido para YTC_WEB_BACKEND_CACHE_TTL_SECONDS.") from exc
+    return max(value, 0)
+
+
+def _fetch_from_api() -> Dict[str, Any]:
+    token_path = _token_path()
+    creds = Credentials.from_authorized_user_file(token_path, SCOPES)
+    yt = build("youtube", "v3", credentials=creds, cache_discovery=False)
+
+    broadcast_response = (
+        yt.liveBroadcasts()
+        .list(part="id,contentDetails,status,snippet", mine=True, maxResults=5)
+        .execute()
+    )
+    broadcasts = broadcast_response.get("items", [])
+    live_broadcast = next(
+        (
+            item
+            for item in broadcasts
+            if item.get("status", {}).get("lifeCycleStatus") in {"live", "testing", "ready"}
+        ),
+        None,
+    )
+
+    updated_at = _isoformat(_now())
+
+    if not live_broadcast:
+        return {
+            "status": "offline",
+            "message": "Nenhuma transmissão ao vivo detectada pela API.",
+            "updatedAt": updated_at,
+        }
+
+    lifecycle_status = live_broadcast.get("status", {}).get("lifeCycleStatus")
+    aggregated_status = "live"
+    if lifecycle_status in {"testing", "ready"}:
+        aggregated_status = "starting"
+    elif lifecycle_status not in {"live", "testing", "ready"}:
+        aggregated_status = "offline"
+
+    stream_id = live_broadcast.get("contentDetails", {}).get("boundStreamId")
+    stream_status: Dict[str, Optional[str]] = {}
+    if stream_id:
+        stream_response = (
+            yt.liveStreams().list(part="id,status,cdn", id=stream_id, maxResults=1).execute()
+        )
+        stream_items = stream_response.get("items", [])
+        if stream_items:
+            stream = stream_items[0]
+            health = stream.get("status", {}).get("healthStatus", {})
+            stream_status = {
+                "streamStatus": stream.get("status", {}).get("streamStatus"),
+                "healthStatus": health.get("status"),
+            }
+
+    snippet = live_broadcast.get("snippet", {})
+    result: Dict[str, Any] = {
+        "status": aggregated_status,
+        "videoId": live_broadcast.get("id"),
+        "title": snippet.get("title"),
+        "scheduledStartTime": snippet.get("scheduledStartTime"),
+        "actualStartTime": snippet.get("actualStartTime"),
+        "health": stream_status or None,
+        "updatedAt": updated_at,
+    }
+    if aggregated_status != "live":
+        result.setdefault("message", "Transmissão preparada, aguardando início.")
+    return result
+
+
+def fetch_live_status(*, force_refresh: bool = False) -> Dict[str, Any]:
+    """Fetch live status, optionally bypassing the cache."""
+    ttl = _cache_ttl_seconds()
+    if not force_refresh:
+        with _cache_lock:
+            expires_at: Optional[datetime] = _cache.get("expires_at")
+            if expires_at and expires_at > _now():
+                return _cache["value"]
+
+    try:
+        result = _fetch_from_api()
+    except HttpError as exc:
+        _logger.exception("Erro ao consultar API do YouTube: %s", exc)
+        result = {
+            "status": "unknown",
+            "message": "Falha ao consultar API do YouTube.",
+            "updatedAt": _isoformat(_now()),
+        }
+    except Exception as exc:  # pragma: no cover - proteção adicional
+        _logger.exception("Erro inesperado ao obter status: %s", exc)
+        raise
+
+    with _cache_lock:
+        _cache["value"] = result
+        _cache["expires_at"] = _now() + timedelta(seconds=ttl)
+    return result
+
+
+@app.get("/api/live-status")
+def get_live_status(force_refresh: bool = False) -> Dict[str, Any]:
+    """Return the cached live status."""
+    try:
+        return fetch_live_status(force_refresh=force_refresh)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc
+    except Exception as exc:  # pragma: no cover - unexpected runtime errors
+        _logger.exception("Erro crítico no endpoint /api/live-status: %s", exc)
+        raise HTTPException(status_code=500, detail="Erro interno ao obter status.") from exc

--- a/secondary-droplet/ytc-web-backend/requirements.txt
+++ b/secondary-droplet/ytc-web-backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi>=0.111,<0.112
+uvicorn[standard]>=0.30,<0.31

--- a/ytc-web/backend-service.md
+++ b/ytc-web/backend-service.md
@@ -39,3 +39,10 @@ Este guia descreve como montar um microserviço HTTP na droplet secundária que 
 - **Actualizações**: quando a especificação do endpoint mudar, sincronize com `status-endpoint.md` e notifique a equipa web.
 - **Fallback**: em caso de indisponibilidade da API, devolva um JSON com `status="unknown"` e mensagem amigável, permitindo que o front-end apresente o aviso secundário.
 
+## Automação disponível no repositório
+
+- O deploy automático é orquestrado por `scripts/deploy_to_droplet.sh`, que sincroniza `secondary-droplet/` (incluindo `ytc-web-backend/`) e executa `scripts/post_deploy.sh`.
+- O script `secondary-droplet/bin/ytc_web_backend_setup.sh` prepara `/opt/ytc-web-service`, cria o virtualenv, instala as dependências (`secondary-droplet/requirements.txt` + `ytc-web-backend/requirements.txt`) e aplica o unit file `secondary-droplet/systemd/ytc-web-backend.service`.
+- As variáveis sensíveis vivem em `/etc/ytc-web-backend.env`. Edite `YT_OAUTH_TOKEN_PATH` (padrão: `/root/token.json`) e `YTC_WEB_BACKEND_CACHE_TTL_SECONDS` conforme a necessidade; o ficheiro é criado com `chmod 600`.
+- Após o deploy, valide o serviço com `systemctl status ytc-web-backend.service` e analise logs recentes via `journalctl -u ytc-web-backend.service -n 50`.
+


### PR DESCRIPTION
## Summary
- add a FastAPI-based `/api/live-status` app for the secondary droplet with cached calls to the YouTube API
- introduce provisioning assets (setup script, requirements, systemd unit) to install and run the service under systemd
- update deployment workflow and documentation to cover the new backend automation

## Testing
- python -m compileall secondary-droplet/ytc-web-backend/app.py

------
https://chatgpt.com/codex/tasks/task_e_68e2e7455bcc8322929311c854f9219f