### PR TITLE
Ensure python3 venv availability during post deploy

### DIFF
--- a/scripts/post_deploy.sh
+++ b/scripts/post_deploy.sh
@@ -3,6 +3,34 @@ set -euo pipefail
 
 cd /root/bwb-stream2yt/secondary-droplet
 
+# Garante que o módulo venv esteja disponível antes de preparar o backend
+ensure_python3_venv() {
+    if python3 -m venv --help >/dev/null 2>&1; then
+        echo "[post_deploy] python3 venv disponível; nenhum pacote adicional necessário."
+        return
+    fi
+
+    echo "[post_deploy] python3 venv ausente; iniciando instalação do pacote python3-venv..."
+    apt-get update
+
+    if apt-get install -y python3-venv; then
+        echo "[post_deploy] Pacote python3-venv instalado com sucesso."
+    else
+        python_minor_version="$(python3 -V 2>&1 | awk '{print $2}' | cut -d. -f1,2)"
+        fallback_package="python${python_minor_version}-venv"
+        echo "[post_deploy] python3-venv indisponível; tentando instalar ${fallback_package}..."
+        apt-get install -y "${fallback_package}"
+        echo "[post_deploy] Pacote ${fallback_package} instalado com sucesso."
+    fi
+
+    if python3 -m venv --help >/dev/null 2>&1; then
+        echo "[post_deploy] python3 venv validado após instalação."
+    else
+        echo "[post_deploy] ERRO: python3 venv permanece indisponível após instalar dependências." >&2
+        exit 1
+    fi
+}
+
 # Instalar dependências (idempotente)
 pip3 install -r requirements.txt
 
@@ -53,6 +81,8 @@ systemctl restart youtube-fallback.service || true
 
 # Mantemos token.json intacto; /etc/youtube-fallback.env é regenerado preservando YT_KEY.
 echo "[post_deploy] youtube-fallback atualizado e env sincronizado."
+
+ensure_python3_venv
 
 echo "[post_deploy] Configurando ytc-web-backend..."
 bin/ytc_web_backend_setup.sh

--- a/secondary-droplet/ytc-web-backend/README.md
+++ b/secondary-droplet/ytc-web-backend/README.md
@@ -1,0 +1,12 @@
+# ytc-web-backend
+
+## Verificando dependências do sistema
+
+Antes de executar o script de setup (`bin/ytc_web_backend_setup.sh`) confirme que a droplet possui o módulo `venv` instalado para o Python 3. Sem ele, a criação do ambiente virtual irá falhar.
+
+Execute um dos comandos abaixo:
+
+- `dpkg -s python3-venv` — retorna o estado do pacote e confirma se está instalado.
+- `python3 -m venv --help` — imprime a ajuda do módulo `venv` quando está disponível.
+
+Caso os comandos indiquem ausência do módulo/pacote, instale-o com `apt install python3-venv` (ou a variante específica da versão, por exemplo `python3.11-venv`).

--- a/ytc-web/backend-service.md
+++ b/ytc-web/backend-service.md
@@ -6,6 +6,7 @@ Este guia descreve como montar um microserviço HTTP na droplet secundária que 
 
 - Droplet já configurada com o token OAuth (`/root/token.json`) utilizado pelos scripts `yt_api_probe_once.py`.
 - Python 3.11 (o mesmo usado no repositório) e dependências listadas em `requirements-dev.txt` para reuso do cliente da API.
+- Pacote `python3-venv` instalado (`apt install python3-venv`) para permitir a criação do ambiente virtual do serviço.
 - Acesso SSH privilegiado para configurar `systemd`, firewalls e variáveis de ambiente.
 
 ## Passos de implementação


### PR DESCRIPTION
## Summary
- ensure the post_deploy script verifies python3 venv availability and installs the appropriate package when missing
- document the python3-venv requirement in the backend service guide
- add backend README notes on checking python3-venv manually

## Testing
- bash -n scripts/post_deploy.sh

------
https://chatgpt.com/codex/tasks/task_e_68e2eadea4f88322b51d25ea532b7490