### PR TITLE
Handle backend venv recreation during deploy

### DIFF
--- a/scripts/post_deploy.sh
+++ b/scripts/post_deploy.sh
@@ -82,10 +82,9 @@ systemctl restart youtube-fallback.service || true
 # Mantemos token.json intacto; /etc/youtube-fallback.env é regenerado preservando YT_KEY.
 echo "[post_deploy] youtube-fallback atualizado e env sincronizado."
 
+echo "[post_deploy] Preparando backend do ytc-web via secondary-droplet/bin/ytc_web_backend_setup.sh..."
 ensure_python3_venv
-
-echo "[post_deploy] Configurando ytc-web-backend..."
-bin/ytc_web_backend_setup.sh
+/root/bwb-stream2yt/secondary-droplet/bin/ytc_web_backend_setup.sh
 
 systemctl daemon-reload
 systemctl enable --now ytc-web-backend.service

--- a/secondary-droplet/bin/ytc_web_backend_setup.sh
+++ b/secondary-droplet/bin/ytc_web_backend_setup.sh
@@ -67,13 +67,25 @@ ensure_firewall_rule() {
 log "Preparando diretório da aplicação em ${INSTALL_DIR}"
 install -d -m 755 -o root -g root "${INSTALL_DIR}"
 
-if [ ! -d "${VENV_DIR}" ]; then
-  log "Criando virtualenv em ${VENV_DIR}"
-  python3 -m venv "${VENV_DIR}"
+if [[ -x "${VENV_DIR}/bin/pip" ]]; then
+  log "Reaproveitando virtualenv existente em ${VENV_DIR}"
+else
+  if [[ -d "${VENV_DIR}" ]]; then
+    log "pip ausente ou não executável; removendo virtualenv corrompido em ${VENV_DIR}"
+    rm -rf "${VENV_DIR}"
+  fi
+
+  log "Reconstruindo virtualenv em ${VENV_DIR}"
+  if python3 -m venv "${VENV_DIR}"; then
+    log "Virtualenv recriado com sucesso"
+  else
+    log "Falha ao criar virtualenv em ${VENV_DIR}" >&2
+    exit 1
+  fi
 fi
 
 log "Actualizando pip e instalando dependências"
-"${VENV_DIR}/bin/pip" install --upgrade pip
+"${VENV_DIR}/bin/python" -m pip install --upgrade pip
 "${VENV_DIR}/bin/pip" install -r "${PROJECT_ROOT}/requirements.txt"
 "${VENV_DIR}/bin/pip" install -r "${APP_SRC}/requirements.txt"
 

--- a/ytc-web/backend-service.md
+++ b/ytc-web/backend-service.md
@@ -45,6 +45,7 @@ Este guia descreve como montar um microserviço HTTP na droplet secundária que 
 
 - O deploy automático é orquestrado por `scripts/deploy_to_droplet.sh`, que sincroniza `secondary-droplet/` (incluindo `ytc-web-backend/`) e executa `scripts/post_deploy.sh`.
 - O script `secondary-droplet/bin/ytc_web_backend_setup.sh` prepara `/opt/ytc-web-service`, cria o virtualenv, instala as dependências (`secondary-droplet/requirements.txt` + `ytc-web-backend/requirements.txt`) e aplica o unit file `secondary-droplet/systemd/ytc-web-backend.service`.
+- Caso o virtualenv fique corrompido (ex.: `pip` ausente), o deploy remove automaticamente `/opt/ytc-web-service/venv` e recria tudo na execução seguinte; confirme o estado com `ls /opt/ytc-web-service/venv/bin/pip` para garantir que o binário existe e é executável.
 - As variáveis sensíveis vivem em `/etc/ytc-web-backend.env`. Edite `YT_OAUTH_TOKEN_PATH` (padrão: `/root/token.json`) e `YTC_WEB_BACKEND_CACHE_TTL_SECONDS` conforme a necessidade; o ficheiro é criado com `chmod 600`.
 - Após o deploy, valide o serviço com `systemctl status ytc-web-backend.service` e analise logs recentes via `journalctl -u ytc-web-backend.service -n 50`.
 


### PR DESCRIPTION
## Summary
- invoke the backend setup helper from post_deploy right after refreshing youtube-fallback
- harden the backend setup script to rebuild the virtualenv when pip is missing and log the action
- document the automatic virtualenv recovery behaviour for operators

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e2eceff538832298eadc613eb3192a