### PR TITLE
Ensure ensurepip availability during backend deploy

### DIFF
--- a/scripts/post_deploy.sh
+++ b/scripts/post_deploy.sh
@@ -5,28 +5,33 @@ cd /root/bwb-stream2yt/secondary-droplet
 
 # Garante que o módulo venv esteja disponível antes de preparar o backend
 ensure_python3_venv() {
-    if python3 -m venv --help >/dev/null 2>&1; then
-        echo "[post_deploy] python3 venv disponível; nenhum pacote adicional necessário."
+    local python_minor_version
+    python_minor_version="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')"
+
+    if python3 -m ensurepip --help >/dev/null 2>&1; then
+        echo "[post_deploy] python3 ensurepip disponível; nenhum pacote adicional necessário."
         return
     fi
 
-    echo "[post_deploy] python3 venv ausente; iniciando instalação do pacote python3-venv..."
+    echo "[post_deploy] python3 ensurepip ausente; instalando suporte a venv para Python ${python_minor_version}..."
     apt-get update
 
-    if apt-get install -y python3-venv; then
-        echo "[post_deploy] Pacote python3-venv instalado com sucesso."
+    if apt-get install -y "python${python_minor_version}-venv"; then
+        echo "[post_deploy] Pacote python${python_minor_version}-venv instalado com sucesso."
     else
-        python_minor_version="$(python3 -V 2>&1 | awk '{print $2}' | cut -d. -f1,2)"
-        fallback_package="python${python_minor_version}-venv"
-        echo "[post_deploy] python3-venv indisponível; tentando instalar ${fallback_package}..."
-        apt-get install -y "${fallback_package}"
-        echo "[post_deploy] Pacote ${fallback_package} instalado com sucesso."
+        echo "[post_deploy] Pacote python${python_minor_version}-venv indisponível; tentando python3-venv..."
+        if apt-get install -y python3-venv; then
+            echo "[post_deploy] Pacote python3-venv instalado com sucesso."
+        else
+            echo "[post_deploy] ERRO: Falha ao instalar python3-venv." >&2
+        fi
     fi
 
-    if python3 -m venv --help >/dev/null 2>&1; then
-        echo "[post_deploy] python3 venv validado após instalação."
+    if python3 -m ensurepip --help >/dev/null 2>&1; then
+        echo "[post_deploy] python3 ensurepip validado após instalação."
     else
-        echo "[post_deploy] ERRO: python3 venv permanece indisponível após instalar dependências." >&2
+        echo "[post_deploy] ERRO: python3 ensurepip permanece indisponível após instalar dependências." >&2
+        echo "[post_deploy] Abandonando deploy do backend para evitar estado parcialmente configurado." >&2
         exit 1
     fi
 }

--- a/ytc-web/backend-service.md
+++ b/ytc-web/backend-service.md
@@ -6,7 +6,7 @@ Este guia descreve como montar um microserviço HTTP na droplet secundária que 
 
 - Droplet já configurada com o token OAuth (`/root/token.json`) utilizado pelos scripts `yt_api_probe_once.py`.
 - Python 3.11 (o mesmo usado no repositório) e dependências listadas em `requirements-dev.txt` para reuso do cliente da API.
-- Pacote `python3-venv` instalado (`apt install python3-venv`) para permitir a criação do ambiente virtual do serviço.
+- Pacote `python3.X-venv` (substitua `X` pela versão menor activa, ex.: `apt install python3.11-venv`) ou `python3-venv` instalado para permitir a criação do ambiente virtual do serviço. Valide antes do deploy com `dpkg -s python3.X-venv` (ajustando para a versão utilizada) **ou** executando `python3 -m ensurepip --help`.
 - Acesso SSH privilegiado para configurar `systemd`, firewalls e variáveis de ambiente.
 
 ## Passos de implementação


### PR DESCRIPTION
## Summary
- ensure the post-deploy script detects the active Python minor version and installs the matching venv package when ensurepip is missing
- abort backend setup if ensurepip remains unavailable after package installation attempts
- document the python-venv prerequisite and validation steps for the backend service guide

## Testing
- not run (deployment script update only)


------
https://chatgpt.com/codex/tasks/task_e_68e2f2491da083228a8951852da4b42f