### PR TITLE
Adjust droplet deploy script for manual post-deploy step

### DIFF
--- a/scripts/deploy_to_droplet.sh
+++ b/scripts/deploy_to_droplet.sh
@@ -14,5 +14,5 @@ rsync -avz --delete \
 rsync -avz --delete \
   "$(dirname "$0")/post_deploy.sh" "${DEST_USER}@${DEST_IP}:${DEST_DIR}/scripts/post_deploy.sh"
 
-ssh -o StrictHostKeyChecking=accept-new "${DEST_USER}@${DEST_IP}" "bash '${DEST_DIR}/scripts/post_deploy.sh'"
-echo "[deploy] Done."
+echo "[deploy] Sync complete. To finish deployment, execute:"
+echo "[deploy]   ssh ${DEST_USER}@${DEST_IP} \"bash '${DEST_DIR}/scripts/post_deploy.sh'\""


### PR DESCRIPTION
## Summary
- stop the deploy helper from automatically running the post-deploy script on the remote droplet
- add a reminder message prompting operators to run the post-deploy script manually once sync finishes

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e2f7bc32708322bcc9e49a0a31dc98