### PR TITLE
Keep fallback services running when using ytc-web disable stub

### DIFF
--- a/docs/diagnostics/20251006-secondary-backup.md
+++ b/docs/diagnostics/20251006-secondary-backup.md
@@ -1,0 +1,37 @@
+# Diagnóstico 2025-10-06 — Falha no envio pela URL secundária do YouTube
+
+Fonte: [`diags/history/diagnostics-antes-restart-20251006-002341Z.txt`](../../diags/history/diagnostics-antes-restart-20251006-002341Z.txt)
+
+## Resumo
+- O `youtube-fallback.service`, responsável por enviar o slate para a URL secundária, está a ser terminado repetidamente pelo OOM killer (código de saída 137) e por falhas subsequentes do `ffmpeg` logo após o reinício.
+- A máquina analisada tem apenas 957 MiB de RAM disponível e **sem swap**, com ~412 MiB já utilizados no momento da recolha, o que deixa pouca margem para o `ffmpeg` operar de forma estável.
+- A queda do serviço secundário coincide temporalmente com falhas no `yt-decider-daemon`, que não consegue contactar `oauth2.googleapis.com` (falhas DNS temporárias) para renovar as credenciais, impedindo qualquer automatização de recuperação.
+- O mini-projecto **ytc-web** é independente destes serviços de fallback; `yt-decider-daemon` e `youtube-fallback` integram a infraestrutura de emissão secundária e devem permanecer activos mesmo quando o backend web está em manutenção.
+
+## Evidências principais
+
+### Recursos do sistema
+- Memória física limitada (957 MiB) e ausência de swap disponíveis: ver bloco `free -h` no diagnóstico.
+- O serviço `youtube-fallback` é relançado muitas vezes e volta a consumir rapidamente CPU/memória antes de ser terminado (registos do `systemd`).
+
+### Terminações do `youtube-fallback.service`
+- Diversas entradas com `A process of this unit has been killed by the OOM killer.` entre `20:18` e `23:51 UTC` do dia 5 de Outubro, seguidas de código de saída `137` (processo terminado pelo kernel).
+- Depois dos reinícios automáticos, o `ffmpeg` não chega a estabilizar a saída; o ficheiro de progresso (`/run/youtube-fallback.progress`) mostra apenas 11 frames enviados (~3,3 s de vídeo) antes da interrupção.
+
+### Falhas do `yt-decider-daemon`
+- Às `20:21:50 UTC`, o daemon termina com `ServerNotFoundError: Unable to find the server at oauth2.googleapis.com`, demonstrando problemas de resolução DNS/ligação à Internet naquele momento.
+- Após a falha, o serviço é reiniciado, mas volta a parar mais tarde, deixando o fallback sem orquestração automática.
+
+## Conclusões e próximos passos
+1. **Mitigar falta de memória (bloqueador principal)**
+   - Aumentar os recursos do droplet (mínimo 2 GiB de RAM) **ou** criar swap persistente de 1–2 GiB (`fallocate -l 2G /swapfile && chmod 600 /swapfile && mkswap /swapfile && swapon /swapfile`), adicionando ` /swapfile swap swap defaults 0 0` a `/etc/fstab` para tornar a alteração permanente.
+   - Se já aumentou a RAM para 1 GiB, confirme com `free -h`/`grep MemTotal /proc/meminfo` que o SO vê efectivamente esse valor e que não existe sobre-alocação por outros serviços (`ps --sort=-%mem -eo pid,cmd,%mem | head`). Caso contrário, a pressão de memória continuará a desencadear o OOM killer mesmo com o dobro da RAM.
+   - Reiniciar o `youtube-fallback.service` apenas depois de garantir que a memória adicional está disponível e confirmar que o processo `ffmpeg` já não termina com código 137 (`journalctl -u youtube-fallback --since "2025-10-05 20:00"`).
+   - Caso o consumo continue elevado, ajustar o `ffmpeg` para um perfil mais leve (por exemplo, reduzir `-b:v` ou resolução) e acompanhar o impacto em `/run/youtube-fallback.progress`.
+2. **Verificar conectividade DNS/Internet**
+   - Validar resolução DNS para `oauth2.googleapis.com` com `dig`/`systemd-resolve`; se falhar, rever os servidores DNS configurados e garantir que a firewall (ou `ufw`) permite saídas TCP/443.
+   - Assim que a conectividade for restabelecida, forçar a renovação das credenciais (`systemctl restart yt-decider-daemon`) e monitorizar `journalctl -u yt-decider-daemon` em busca de novos erros.
+3. **Monitorizar recuperação automática**
+   - Utilizar `systemctl status youtube-fallback yt-decider-daemon` para confirmar que ambos os serviços permanecem activos durante pelo menos 10–15 minutos após as correcções.
+   - Adicionar alarmes em `prometheus`/`grafana` (ou scripts existentes) para alertar sobre novos eventos do OOM killer e falhas de DNS, evitando regressões futuras.
+

--- a/secondary-droplet/bin/ytc_web_backend_disable_stub.sh
+++ b/secondary-droplet/bin/ytc_web_backend_disable_stub.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Desliga apenas o backend ytc-web. Não afecta os serviços de fallback (yt-decider-daemon/youtube-fallback).
+set -euo pipefail
+
+log() {
+    echo "[ytc-web-backend-disable] $*"
+}
+
+log "Iniciando desligamento do mini-projecto ytc-web"
+
+if systemctl list-unit-files | grep -q '^ytc-web-backend.service'; then
+    log "Parando ytc-web-backend.service"
+    systemctl stop ytc-web-backend.service || log "Aviso: falha ao parar ytc-web-backend.service"
+
+    log "Desativando arranque automático do ytc-web-backend.service"
+    systemctl disable ytc-web-backend.service || log "Aviso: falha ao desativar ytc-web-backend.service"
+else
+    log "ytc-web-backend.service não encontrado no systemd"
+fi
+
+log "ytc-web-backend.service desligado (demais serviços permanecem activos)."

--- a/ytc-web/backend-service.md
+++ b/ytc-web/backend-service.md
@@ -32,4 +32,5 @@ Este guia descreve como montar um microserviço HTTP na droplet secundária que 
 - **Actualizações**: quando a especificação do endpoint mudar, sincronize com `status-endpoint.md` e notifique a equipa web.
 - **Fallback**: em caso de indisponibilidade da API, devolva um JSON com `status="unknown"` e mensagem amigável, permitindo que o front-end apresente o aviso secundário.
 - **Execução de scripts**: execute primeiro `./scripts/deploy_to_droplet.sh` (que apenas sincroniza ficheiros) e depois, já na droplet, `bash /root/bwb-stream2yt/scripts/post_deploy.sh`. O script instala `python3-venv` se necessário, aplica firewall e deixa a shell fora do virtualenv ao concluir.
+- **Desligar temporariamente o backend**: para isolar problemas de recursos ou evitar interferências durante investigações, utilize `bash /root/bwb-stream2yt/secondary-droplet/bin/ytc_web_backend_disable_stub.sh`. O stub actua **apenas** sobre `ytc-web-backend.service`, deixando `yt-decider-daemon` e `youtube-fallback` activos para que a emissão secundária continue operacional.
 


### PR DESCRIPTION
## Summary
- restrict the ytc-web disable stub to only stop the backend service and document that fallback services stay running
- clarify in the backend service guide that the stub does not touch yt-decider-daemon or youtube-fallback
- add diagnostic guidance reminding that yt-decider-daemon and youtube-fallback belong to the secondary fallback stack, not the ytc-web project

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68e30d2ccc7483228bf94b5322f459a5