### PR TITLE
Add single-instance mutex and enforce droplet backup ingest

### DIFF
--- a/secondary-droplet/bin/youtube_fallback.sh
+++ b/secondary-droplet/bin/youtube_fallback.sh
@@ -155,6 +155,14 @@ fi
 
 YT_URL_BACKUP="$(normalize_backup_url "${YT_URL_BACKUP-}" "$YT_KEY")"
 
+if [[ "${YT_URL_BACKUP}" != *"?backup=1/"* ]]; then
+  echo "[youtube_fallback] ERRO: URL de backup inválida (falta '?backup=1/')."; exit 1
+fi
+
+if [[ "${YT_URL_BACKUP}" == *"rtmps://a.rtmps.youtube.com"* ]]; then
+  echo "[youtube_fallback] ERRO: URL aponta para ingest primário; utilize sempre a porta de backup."; exit 1
+fi
+
 echo "[youtube_fallback] Envio contínuo → ${YT_URL_BACKUP}"
 echo "[youtube_fallback] ${FALLBACK_WIDTH}x${FALLBACK_HEIGHT}@${FALLBACK_FPS} | V=${FALLBACK_VBITRATE}/${FALLBACK_MAXRATE}/${FALLBACK_BUFSIZE} | A=${FALLBACK_ABITRATE}@${FALLBACK_AR} | Delay=${FALLBACK_DELAY_SEC}s | GOP=${FALLBACK_GOP} | LogLevel=${FALLBACK_LOGLEVEL}"
 


### PR DESCRIPTION
## Summary
- prevent launching multiple copies of the Windows primary sender by acquiring a named mutex alongside the PID file
- release the mutex on shutdown and extend startup logging to explain the guard behaviour
- hard-stop the droplet fallback script when a primary ingest URL is detected or the backup flag is missing

## Testing
- pytest tests/test_stream_to_youtube.py


------
https://chatgpt.com/codex/tasks/task_e_6904b230ddd083229608e067f0613d24