### PR TITLE
fix: remove embedded RTSP credentials from defaults

### DIFF
--- a/primary-windows/src/.env.example
+++ b/primary-windows/src/.env.example
@@ -8,7 +8,14 @@
 #YT_URL=rtmps://a.rtmps.youtube.com/live2/SEU_CODIGO_DO_YOUTUBE
 
 # Parâmetros de entrada para o ffmpeg. Ajuste o endereço RTSP conforme necessário.
-#YT_INPUT_ARGS=-rtsp_transport tcp -rtsp_flags prefer_tcp -fflags nobuffer -flags low_delay -use_wallclock_as_timestamps 1 -i rtsp://USUARIO:SenhaFort3@10.0.254.50:554/Streaming/Channels/101
+#YT_INPUT_ARGS=-rtsp_transport tcp -rtsp_flags prefer_tcp -fflags nobuffer -flags low_delay -use_wallclock_as_timestamps 1 -i rtsp://UTILIZADOR_RTSP:PALAVRA_PASSE@192.0.2.10:554/Streaming/Channels/101
+
+# Também é possível deixar YT_INPUT_ARGS vazio e informar as variáveis abaixo.
+#RTSP_HOST=192.0.2.10
+#RTSP_PORT=554
+#RTSP_PATH=Streaming/Channels/101
+#RTSP_USERNAME=UTILIZADOR_RTSP
+#RTSP_PASSWORD=PALAVRA_PASSE
 
 # Parâmetros de saída para o ffmpeg. Utilize para alterar codec, bitrate ou filtros.
 #YT_OUTPUT_ARGS=-vf scale=1920:1080:flags=bicubic,format=yuv420p -r 30 -c:v libx264 -preset veryfast -profile:v high -level 4.2 -b:v 4500k -pix_fmt yuv420p -g 60 -c:a aac -b:a 128k -ar 44100 -f flv
@@ -19,9 +26,9 @@
 # Caminho para o executável ffmpeg. Deixe vazio para usar o ffmpeg no PATH.
 #FFMPEG=C:\\caminho\\para\\ffmpeg.exe
 
-# Credenciais RTSP padrão (exemplo). Substitua conforme o dispositivo utilizado.
-#RTSP_USERNAME=USUARIO
-#RTSP_PASSWORD=SenhaFort3
+# Credenciais RTSP (exemplo fictício). Substitua pelos valores reais do dispositivo.
+#RTSP_USERNAME=UTILIZADOR_RTSP
+#RTSP_PASSWORD=PALAVRA_PASSE
 
 # Janela diária de transmissão.
 # Hora inicial, inclusive.

--- a/primary-windows/src/stream_to_youtube.py
+++ b/primary-windows/src/stream_to_youtube.py
@@ -65,16 +65,16 @@ ENV_TEMPLATE_CONTENT = """# Configurações para stream_to_youtube.py
 #YT_URL=rtmps://a.rtmps.youtube.com/live2/SEU_CODIGO_DO_YOUTUBE
 
 # Parâmetros de entrada para o ffmpeg. Ajuste o endereço RTSP conforme necessário.
-#YT_INPUT_ARGS=-rtsp_transport tcp -rtsp_flags prefer_tcp -fflags nobuffer -flags low_delay -use_wallclock_as_timestamps 1 -i rtsp://USUARIO:SenhaFort3@10.0.254.50:554/Streaming/Channels/101
+#YT_INPUT_ARGS=-rtsp_transport tcp -rtsp_flags prefer_tcp -fflags nobuffer -flags low_delay -use_wallclock_as_timestamps 1 -i rtsp://UTILIZADOR_RTSP:PALAVRA_PASSE@192.0.2.10:554/Streaming/Channels/101
 
 # Também é possível deixar `YT_INPUT_ARGS` vazio e informar as variáveis abaixo para montar
 # automaticamente a URL RTSP. Todas são opcionais e só são utilizadas quando `YT_INPUT_ARGS`
 # permanecer em branco.
-#RTSP_HOST=10.0.254.50
+#RTSP_HOST=192.0.2.10
 #RTSP_PORT=554
 #RTSP_PATH=Streaming/Channels/101
-#RTSP_USERNAME=USUARIO
-#RTSP_PASSWORD=SenhaFort3
+#RTSP_USERNAME=UTILIZADOR_RTSP
+#RTSP_PASSWORD=PALAVRA_PASSE
 
 # Parâmetros de saída para o ffmpeg. Utilize para alterar codec, bitrate ou filtros.
 #YT_OUTPUT_ARGS=-vf scale=1920:1080:flags=bicubic:in_range=pc:out_range=tv,format=yuv420p -r 30 -c:v libx264 -preset veryfast -profile:v high -level 4.2 -b:v 4500k -pix_fmt yuv420p -g 60 -c:a aac -b:a 128k -ar 44100 -f flv
@@ -1322,9 +1322,12 @@ _DEFAULT_INPUT_ARGS = [
     "low_delay",
     "-use_wallclock_as_timestamps",
     "1",
-    "-i",
-    "rtsp://BEACHCAM:QueriasEntrar123@10.0.254.50:554/Streaming/Channels/101",
 ]
+
+_MISSING_INPUT_SOURCE_ERROR = (
+    "Configuração de entrada ausente: defina YT_INPUT_ARGS ou "
+    "RTSP_HOST e RTSP_PATH (e RTSP_USERNAME/RTSP_PASSWORD se necessário)."
+)
 
 
 def _default_input_args() -> list[str]:
@@ -1661,7 +1664,11 @@ def _resolve_heartbeat_config(base_dir: Path) -> HeartbeatConfig:
     )
 
 
-def load_config(resolution: Optional[str] = None) -> StreamingConfig:
+def load_config(
+    resolution: Optional[str] = None,
+    *,
+    require_input_source: bool = True,
+) -> StreamingConfig:
     _ensure_env_file()
     _load_env_files()
 
@@ -1672,7 +1679,9 @@ def load_config(resolution: Optional[str] = None) -> StreamingConfig:
         default_input_args = _default_input_args()
         rtsp_url = _build_rtsp_url_from_env()
         if rtsp_url:
-            input_args = default_input_args[:-1] + [rtsp_url]
+            input_args = default_input_args + ["-i", rtsp_url]
+        elif require_input_source:
+            raise ValueError(_MISSING_INPUT_SOURCE_ERROR)
         else:
             input_args = default_input_args
     output_args = _split_args(
@@ -2824,7 +2833,10 @@ def _start_streaming_instance(
 
             try:
                 logger.log("A carregar configuração de streaming.")
-                config = load_config(resolution=resolution)
+                config = load_config(
+                    resolution=resolution,
+                    require_input_source=demo_video_path is None and input_args is None,
+                )
                 if demo_video_path is not None:
                     config = apply_demo_video_source(config, demo_video_path)
                     logger.log(

--- a/primary-windows/src/ui_app.py
+++ b/primary-windows/src/ui_app.py
@@ -524,7 +524,10 @@ def run_ui_app(*, resolution: Optional[str] = None) -> int:
 
         def _create_preview_session(self):
             try:
-                config = load_config(resolution=self._resolution)
+                config = load_config(
+                    resolution=self._resolution,
+                    require_input_source=not self._demo_enabled,
+                )
                 if self._demo_enabled:
                     path = resolve_demo_video_path()
                     self._demo_path = path

--- a/tests/test_demo_video.py
+++ b/tests/test_demo_video.py
@@ -247,7 +247,7 @@ def test_start_streaming_demo_missing_file_returns_3(tmp_path, monkeypatch):
 def test_start_streaming_without_demo_keeps_rtsp_path(tmp_path, monkeypatch):
     captured = {}
 
-    def fake_load_config(resolution=None):
+    def fake_load_config(resolution=None, **_kwargs):
         return module.StreamingConfig(
             yt_url="rtmps://example/live2/key",
             input_args=["-i", "rtsp://cam/stream"],
@@ -304,7 +304,7 @@ def test_start_streaming_demo_uses_mp4_without_changing_env(tmp_path, monkeypatc
     video.write_bytes(b"data")
     captured = {}
 
-    def fake_load_config(resolution=None):
+    def fake_load_config(resolution=None, **_kwargs):
         return module.StreamingConfig(
             yt_url="rtmps://example/live2/key",
             input_args=["-i", "rtsp://cam/stream"],

--- a/tests/test_rtsp_input_config.py
+++ b/tests/test_rtsp_input_config.py
@@ -1,0 +1,129 @@
+"""Testes da configuração de entrada RTSP sem credenciais embutidas."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "primary-windows"
+    / "src"
+    / "stream_to_youtube.py"
+)
+SRC_DIR = MODULE_PATH.parent
+if str(SRC_DIR) not in sys.path:
+    sys.path.insert(0, str(SRC_DIR))
+
+SPEC = importlib.util.spec_from_file_location(
+    "_stream_to_youtube_rtsp_cfg", MODULE_PATH
+)
+assert SPEC and SPEC.loader
+module = importlib.util.module_from_spec(SPEC)
+sys.modules["_stream_to_youtube_rtsp_cfg"] = module
+
+if "autotune" not in sys.modules:
+    autotune_stub = types.ModuleType("autotune")
+
+    def _estimate_upload_bitrate(*_args, **_kwargs):
+        raise NotImplementedError
+
+    autotune_stub.estimate_upload_bitrate = _estimate_upload_bitrate  # type: ignore[attr-defined]
+    autotune_stub.AUTOTUNE_AVAILABLE = False  # type: ignore[attr-defined]
+    autotune_stub.AUTOTUNE_UNAVAILABLE_REASON = ""  # type: ignore[attr-defined]
+    sys.modules["autotune"] = autotune_stub
+
+SPEC.loader.exec_module(module)
+
+
+@pytest.fixture(autouse=True)
+def _clear_input_env(monkeypatch):
+    for key in (
+        "YT_INPUT_ARGS",
+        "RTSP_HOST",
+        "RTSP_PORT",
+        "RTSP_PATH",
+        "RTSP_USERNAME",
+        "RTSP_PASSWORD",
+        "YT_URL",
+        "YT_KEY",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(module, "_ensure_env_file", lambda: None)
+    monkeypatch.setattr(module, "_load_env_files", lambda: None)
+
+
+def test_default_input_args_have_no_rtsp_url():
+    args = module._default_input_args()
+    joined = " ".join(args)
+    assert "-i" not in args
+    assert "rtsp://" not in joined.lower()
+    assert "@" not in joined
+
+
+def test_load_config_uses_yt_input_args(monkeypatch):
+    monkeypatch.setenv(
+        "YT_INPUT_ARGS",
+        "-rtsp_transport tcp -i rtsp://UTILIZADOR_RTSP:PALAVRA_PASSE@192.0.2.10:554/stream",
+    )
+    monkeypatch.setenv("YT_URL", "rtmps://a.rtmps.youtube.com/live2/EXEMPLO")
+    config = module.load_config()
+    assert config.input_args[-2:] == [
+        "-i",
+        "rtsp://UTILIZADOR_RTSP:PALAVRA_PASSE@192.0.2.10:554/stream",
+    ]
+
+
+def test_load_config_builds_rtsp_from_env_vars(monkeypatch):
+    monkeypatch.setenv("RTSP_HOST", "192.0.2.10")
+    monkeypatch.setenv("RTSP_PORT", "554")
+    monkeypatch.setenv("RTSP_PATH", "Streaming/Channels/101")
+    monkeypatch.setenv("RTSP_USERNAME", "UTILIZADOR_RTSP")
+    monkeypatch.setenv("RTSP_PASSWORD", "PALAVRA_PASSE")
+    monkeypatch.setenv("YT_URL", "rtmps://a.rtmps.youtube.com/live2/EXEMPLO")
+    config = module.load_config()
+    assert config.input_args[-2] == "-i"
+    assert (
+        config.input_args[-1]
+        == "rtsp://UTILIZADOR_RTSP:PALAVRA_PASSE@192.0.2.10:554/Streaming/Channels/101"
+    )
+    assert config.input_args[0] == "-rtsp_transport"
+
+
+def test_load_config_missing_source_raises_clear_error():
+    with pytest.raises(ValueError, match="Configuração de entrada ausente"):
+        module.load_config()
+
+
+def test_load_config_allows_missing_source_for_demo(monkeypatch):
+    monkeypatch.setenv("YT_URL", "rtmps://a.rtmps.youtube.com/live2/EXEMPLO")
+    config = module.load_config(require_input_source=False)
+    assert "-i" not in config.input_args
+    demo = module.apply_demo_video_source(config, "/tmp/demo-exemplo.mp4")
+    assert demo.demo_mode is True
+    assert any(arg.endswith(".mp4") or "demo" in arg.lower() for arg in demo.input_args)
+    assert "-i" in demo.input_args
+
+
+def test_mask_sensitive_arg_hides_rtsp_password():
+    raw = "rtsp://UTILIZADOR_RTSP:PALAVRA_PASSE@192.0.2.10:554/stream"
+    masked = module._mask_sensitive_arg(raw)
+    assert "PALAVRA_PASSE" not in masked
+    assert "***" in masked
+    assert "UTILIZADOR_RTSP" in masked
+
+
+def test_diagnostics_text_does_not_expose_password(monkeypatch):
+    monkeypatch.setenv(
+        "YT_INPUT_ARGS",
+        "-i rtsp://UTILIZADOR_RTSP:segredo-teste-xyz@192.0.2.10:554/stream",
+    )
+    monkeypatch.setenv("YT_URL", "rtmps://a.rtmps.youtube.com/live2/EXEMPLO")
+    config = module.load_config()
+    text = module._collect_full_diagnostics(config)
+    assert "segredo-teste-xyz" not in text
+    assert "rtsp://UTILIZADOR_RTSP:***@" in text or "***" in text

--- a/tests/test_send_quality.py
+++ b/tests/test_send_quality.py
@@ -192,7 +192,7 @@ def test_apply_send_quality_works_with_demo(tmp_path):
 def test_start_streaming_uses_selected_quality(tmp_path, monkeypatch):
     captured = {}
 
-    def fake_load_config(resolution=None):
+    def fake_load_config(resolution=None, **_kwargs):
         return _build_config(tmp_path)
 
     def fake_run_forever(config, **kwargs):
@@ -221,7 +221,7 @@ def test_start_streaming_uses_selected_quality(tmp_path, monkeypatch):
 def test_start_streaming_without_quality_keeps_env_behavior(tmp_path, monkeypatch):
     captured = {}
 
-    def fake_load_config(resolution=None):
+    def fake_load_config(resolution=None, **_kwargs):
         return _build_config(tmp_path, resolution="720p", bitrate_max_kbps=4500)
 
     def fake_run_forever(config, **kwargs):
@@ -248,7 +248,7 @@ def test_quality_selection_does_not_rewrite_env(tmp_path, monkeypatch):
     original = "YT_URL=rtmps://example/live2/key\nYT_RESOLUTION=1080p\n"
     env_path.write_text(original, encoding="utf-8")
 
-    def fake_load_config(resolution=None):
+    def fake_load_config(resolution=None, **_kwargs):
         return _build_config(tmp_path)
 
     monkeypatch.setattr(module, "load_config", fake_load_config)

--- a/tests/test_stream_to_youtube.py
+++ b/tests/test_stream_to_youtube.py
@@ -322,7 +322,9 @@ def test_startup_log_removed_after_successful_launch(tmp_path, monkeypatch):
     monkeypatch.setattr(module, "run_forever", _fake_run_forever)
 
     config = _build_streaming_config(tmp_path)
-    monkeypatch.setattr(module, "load_config", lambda resolution=None: config)
+    monkeypatch.setattr(
+        module, "load_config", lambda resolution=None, **_kwargs: config
+    )
 
     exit_code = module._start_streaming_instance()
     assert exit_code == 0
@@ -343,7 +345,9 @@ def test_startup_log_preserved_when_credentials_missing(tmp_path, monkeypatch):
     monkeypatch.setattr(module, "_ensure_signal_handlers", lambda: None)
 
     config = _build_streaming_config(tmp_path, yt_url=None)
-    monkeypatch.setattr(module, "load_config", lambda resolution=None: config)
+    monkeypatch.setattr(
+        module, "load_config", lambda resolution=None, **_kwargs: config
+    )
 
     exit_code = module._start_streaming_instance()
     assert exit_code == 2
@@ -373,7 +377,9 @@ def test_startup_log_preserved_when_worker_quits_early(tmp_path, monkeypatch):
     monkeypatch.setattr(module, "run_forever", _fake_run_forever)
 
     config = _build_streaming_config(tmp_path)
-    monkeypatch.setattr(module, "load_config", lambda resolution=None: config)
+    monkeypatch.setattr(
+        module, "load_config", lambda resolution=None, **_kwargs: config
+    )
 
     exit_code = module._start_streaming_instance()
     assert exit_code == 0


### PR DESCRIPTION
## Summary
- Remove URL RTSP com credenciais reais de `_DEFAULT_INPUT_ARGS`
- Defaults passam a ser só argumentos genéricos FFmpeg; a URL vem de `YT_INPUT_ARGS` ou variáveis `RTSP_*`
- Erro de configuração claro e sanitizado quando falta fonte RTSP
- Modo demo continua sem exigir RTSP
- Exemplos (`.env.example` / template) só com valores fictícios (`PALAVRA_PASSE`, `192.0.2.10`)

## Test plan
- [x] pytest (inclui novos testes de configuração RTSP)
- [ ] Confirmar Release corretiva sem a credencial antiga nos ZIPs/binários
- [ ] Utilizador: rodar password RTSP na câmara e atualizar `.env` locais


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed embedded RTSP credentials and stripped the default `-i rtsp://...` from ffmpeg args. Input now comes from `YT_INPUT_ARGS` or `RTSP_*`; we raise a clear error if missing, and demo mode still works without RTSP.

- **Bug Fixes**
  - Defaults no longer include an `-i` RTSP URL; `load_config` adds `-i` only when a URL comes from `YT_INPUT_ARGS` or is built from `RTSP_*`.
  - Added `require_input_source` to control validation; UI sets it so demo mode bypasses the check. Error text is clear and sanitized.
  - Updated `.env.example` with fictitious placeholders and `RTSP_*` examples; tests ensure no secrets in defaults and diagnostics mask RTSP passwords.

- **Migration**
  - Set `YT_INPUT_ARGS` with your RTSP URL, or define `RTSP_HOST`, `RTSP_PATH`, and credentials (`RTSP_USERNAME`/`RTSP_PASSWORD`) in `.env`.
  - Rotate any previously used camera password if it might have been shared; demo mode needs no changes.

<sup>Written for commit acd806ae362c56650360105e5fcad1f4b0cb1b52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/storesace-cv/bwb-stream2yt/pull/204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

