### PR TITLE
fix: keep camera ffprobe inputs free of anullsrc

### DIFF
--- a/primary-windows/src/stream_audio.py
+++ b/primary-windows/src/stream_audio.py
@@ -144,7 +144,10 @@ def probe_input_has_audio(
 
 
 def apply_audio_mode_to_config(config: Any, mode: Optional[str]) -> Any:
-    """Aplica modo de áudio a StreamingConfig (input/output/maps).
+    """Aplica modo de áudio a StreamingConfig (output/maps), sem alterar a fonte.
+
+    ``config.input_args`` continua a representar apenas a câmara ou o MP4.
+    O ``anullsrc`` é acrescentado só em ``build_effective_ffmpeg_input_args``.
 
     Em modo fonte, exige faixa de áudio na entrada; caso contrário levanta
     ``ValueError`` com mensagem orientada ao utilizador.
@@ -169,12 +172,22 @@ def apply_audio_mode_to_config(config: Any, mode: Optional[str]) -> Any:
             audio_detected=True,
         )
 
-    input_args = list(config.input_args) + build_silent_audio_input_args()
     output_args = build_audio_aware_output_args(config.output_args, silent=True)
     return replace(
         config,
-        input_args=input_args,
         output_args=output_args,
         audio_mode=normalized,
         audio_detected=False,
     )
+
+
+def build_effective_ffmpeg_input_args(config: Any) -> List[str]:
+    """Entradas efetivas do FFmpeg principal (fonte + anullsrc se silent)."""
+
+    args = list(getattr(config, "input_args", []) or [])
+    mode = getattr(config, "audio_mode", None)
+    if mode is None:
+        return args
+    if normalize_audio_mode(mode) == AUDIO_MODE_SILENT:
+        return args + build_silent_audio_input_args()
+    return args

--- a/primary-windows/src/stream_to_youtube.py
+++ b/primary-windows/src/stream_to_youtube.py
@@ -47,6 +47,7 @@ from stream_audio import (
     NO_AUDIO_AVAILABLE_MESSAGE,
     apply_audio_mode_to_config,
     audio_mode_label,
+    build_effective_ffmpeg_input_args,
     normalize_audio_mode,
 )
 
@@ -813,6 +814,9 @@ def _collect_full_diagnostics(config: "StreamingConfig") -> str:
     timestamp_text = generated_at.isoformat().replace("+00:00", "Z")
 
     sanitized_input = [_mask_sensitive_arg(arg) for arg in config.input_args]
+    sanitized_effective = [
+        _mask_sensitive_arg(arg) for arg in build_effective_ffmpeg_input_args(config)
+    ]
     sanitized_output = [_mask_sensitive_arg(arg) for arg in config.output_args]
 
     camera_snapshot: Dict[str, Any] = {}
@@ -947,11 +951,17 @@ def _collect_full_diagnostics(config: "StreamingConfig") -> str:
         f"- Intervalo do autotune (s): {config.autotune_interval:.1f}",
         f"- Margem de segurança do autotune: {config.autotune_safety_margin:.2f}",
         f"- URL do YouTube presente: {'sim' if bool(config.yt_url) else 'não'}",
-        "- Argumentos de entrada (ffmpeg):",
+        "- Argumentos de entrada da fonte (ffmpeg/ffprobe):",
     ]
 
     if sanitized_input:
         lines.extend(f"  - {item}" for item in sanitized_input)
+    else:
+        lines.append("  - (nenhum argumento configurado)")
+
+    lines.append("- Argumentos de entrada efetivos do FFmpeg principal:")
+    if sanitized_effective:
+        lines.extend(f"  - {item}" for item in sanitized_effective)
     else:
         lines.append("  - (nenhum argumento configurado)")
 
@@ -960,6 +970,30 @@ def _collect_full_diagnostics(config: "StreamingConfig") -> str:
         lines.extend(f"  - {item}" for item in sanitized_output)
     else:
         lines.append("  - (nenhum argumento configurado)")
+
+    if config.yt_url:
+        sanitized_cmd = " ".join(
+            [
+                str(config.ffmpeg),
+                "-hide_banner",
+                "-loglevel",
+                "warning",
+                "-nostats",
+                "-progress",
+                "pipe:1",
+                *sanitized_effective,
+                *sanitized_output,
+                "-f",
+                "flv",
+                _mask_sensitive_arg(config.yt_url),
+            ]
+        )
+        lines.extend(
+            [
+                "- Comando FFmpeg principal (sanitizado):",
+                f"  {sanitized_cmd}",
+            ]
+        )
 
     lines.extend(
         [
@@ -2429,6 +2463,7 @@ class StreamingWorker:
         return snapshot
 
     def _run_loop(self) -> None:
+        effective_inputs = build_effective_ffmpeg_input_args(self._config)
         print(
             "===== START {} =====".format(
                 datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
@@ -2443,7 +2478,7 @@ class StreamingWorker:
             "-nostats",
             "-progress",
             "pipe:1",
-            *self._config.input_args,
+            *effective_inputs,
             *self._config.output_args,
             "-f",
             "flv",
@@ -2469,6 +2504,7 @@ class StreamingWorker:
                     continue
 
                 output_args = self._prepare_output_args()
+                effective_inputs = build_effective_ffmpeg_input_args(self._config)
                 cmd = [
                     self._config.ffmpeg,
                     "-hide_banner",
@@ -2477,7 +2513,7 @@ class StreamingWorker:
                     "-nostats",
                     "-progress",
                     "pipe:1",
-                    *self._config.input_args,
+                    *effective_inputs,
                     *output_args,
                     "-f",
                     "flv",
@@ -2492,7 +2528,7 @@ class StreamingWorker:
                     "-nostats",
                     "-progress",
                     "pipe:1",
-                    *self._config.input_args,
+                    *effective_inputs,
                     *output_args,
                     "-f",
                     "flv",

--- a/tests/test_ui_settings_audio.py
+++ b/tests/test_ui_settings_audio.py
@@ -24,6 +24,7 @@ from stream_audio import (  # noqa: E402
     NO_AUDIO_AVAILABLE_MESSAGE,
     apply_audio_mode_to_config,
     build_audio_map_args,
+    build_effective_ffmpeg_input_args,
     build_silent_audio_input_args,
     ensure_aac_audio_output_args,
     normalize_audio_mode,
@@ -249,8 +250,9 @@ def test_silent_audio_generates_anullsrc_and_maps():
     assert "anullsrc=" in silent_in[3]
     assert build_audio_map_args(silent=True) == ["-map", "0:v:0", "-map", "1:a:0"]
     updated = apply_audio_mode_to_config(_base_config(), AUDIO_MODE_SILENT)
-    joined = " ".join(updated.input_args)
-    assert "anullsrc=" in joined
+    assert "anullsrc=" not in " ".join(updated.input_args)
+    effective = build_effective_ffmpeg_input_args(updated)
+    assert "anullsrc=" in " ".join(effective)
     assert updated.output_args[:4] == ["-map", "0:v:0", "-map", "1:a:0"]
     assert "-filter:a" not in updated.output_args
     assert ensure_aac_audio_output_args([])[1::2] == ["aac", "128k", "44100", "2"]
@@ -262,8 +264,12 @@ def test_silent_mode_ignores_original_mp4_audio():
         demo_mode=True,
     )
     updated = apply_audio_mode_to_config(config, AUDIO_MODE_SILENT)
+    assert updated.input_args == config.input_args
     assert updated.output_args[2:4] == ["-map", "1:a:0"]
     assert "0:a:0" not in updated.output_args
+    effective = build_effective_ffmpeg_input_args(updated)
+    assert effective[:5] == config.input_args
+    assert effective[-4:-1] == ["-f", "lavfi", "-i"]
 
 
 def test_source_audio_uses_original_track(monkeypatch):
@@ -274,6 +280,7 @@ def test_source_audio_uses_original_track(monkeypatch):
     updated = apply_audio_mode_to_config(_base_config(), AUDIO_MODE_SOURCE)
     assert updated.output_args[:4] == ["-map", "0:v:0", "-map", "0:a:0"]
     assert "anullsrc=" not in " ".join(updated.input_args)
+    assert "anullsrc=" not in " ".join(build_effective_ffmpeg_input_args(updated))
     assert updated.audio_detected is True
 
 
@@ -289,7 +296,75 @@ def test_source_audio_without_track_raises(monkeypatch):
 def test_camera_video_only_works_with_silent():
     updated = apply_audio_mode_to_config(_base_config(), "sem")
     assert normalize_audio_mode("sem") == AUDIO_MODE_SILENT
-    assert "anullsrc=" in " ".join(updated.input_args)
+    assert "anullsrc=" not in " ".join(updated.input_args)
+    assert "anullsrc=" in " ".join(build_effective_ffmpeg_input_args(updated))
+
+
+def test_camera_silent_keeps_monitor_on_rtsp_only():
+    source_args = [
+        "-rtsp_transport",
+        "tcp",
+        "-i",
+        "rtsp://user:segredo@10.1.2.3/stream",
+    ]
+    config = apply_audio_mode_to_config(
+        _base_config(input_args=list(source_args)), AUDIO_MODE_SILENT
+    )
+    assert config.input_args == source_args
+    assert "anullsrc=" not in " ".join(config.input_args)
+    monitor = module.CameraSignalMonitor(
+        "ffprobe",
+        config.input_args,
+        5.0,
+        2.0,
+        False,
+        log_fn=lambda *_a, **_k: None,
+    )
+    assert monitor._input_args == source_args
+    effective = build_effective_ffmpeg_input_args(config)
+    assert effective[:4] == source_args
+    assert effective[4:6] == ["-f", "lavfi"]
+    assert "anullsrc=" in effective[7]
+    assert config.output_args[:4] == ["-map", "0:v:0", "-map", "1:a:0"]
+
+
+def test_demo_silent_orders_mp4_then_anullsrc():
+    demo_args = ["-stream_loop", "-1", "-re", "-i", r"C:\demo\video.mp4"]
+    config = apply_audio_mode_to_config(
+        _base_config(input_args=list(demo_args), demo_mode=True),
+        AUDIO_MODE_SILENT,
+    )
+    effective = build_effective_ffmpeg_input_args(config)
+    assert effective[4] == r"C:\demo\video.mp4"
+    assert effective[5:8] == ["-f", "lavfi", "-i"]
+    assert config.output_args[:4] == ["-map", "0:v:0", "-map", "1:a:0"]
+
+
+def test_camera_source_audio_has_no_anullsrc(monkeypatch):
+    monkeypatch.setattr("stream_audio.probe_input_has_audio", lambda *a, **k: True)
+    source_args = ["-rtsp_transport", "tcp", "-i", "rtsp://cam/stream"]
+    config = apply_audio_mode_to_config(
+        _base_config(input_args=list(source_args)), AUDIO_MODE_SOURCE
+    )
+    assert config.input_args == source_args
+    assert build_effective_ffmpeg_input_args(config) == source_args
+    assert config.output_args[:4] == ["-map", "0:v:0", "-map", "0:a:0"]
+
+
+def test_diagnostics_effective_cmd_hides_rtsp_password():
+    source_args = [
+        "-rtsp_transport",
+        "tcp",
+        "-i",
+        "rtsp://user:segredo-secreto@10.1.2.3/stream",
+    ]
+    config = apply_audio_mode_to_config(
+        _base_config(input_args=list(source_args)), AUDIO_MODE_SILENT
+    )
+    report = module._collect_full_diagnostics(config)
+    assert "segredo-secreto" not in report
+    assert "anullsrc=" in report
+    assert "rtsp://user:***@" in report or "***" in report
 
 
 def test_probe_helper_parses_ffprobe_json():


### PR DESCRIPTION
## Summary
- `config.input_args` mantém apenas a fonte (RTSP/MP4)
- `anullsrc` entra só via `build_effective_ffmpeg_input_args()` no FFmpeg principal e no diagnóstico sanitizado
- `CameraSignalMonitor`/ffprobe continuam a receber apenas a fonte

## Test plan
- [x] pytest / black / flake8
- [ ] Windows: Câmara + Sem áudio → RTMPS “A enviar”


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep `config.input_args` limited to the camera/MP4 source and add `anullsrc` only when launching the main FFmpeg process. This fixes ffprobe/monitor issues and makes diagnostics clearer and safer.

- **Bug Fixes**
  - Introduced `build_effective_ffmpeg_input_args(config)`; `apply_audio_mode_to_config` no longer injects `anullsrc` into `input_args`.
  - `CameraSignalMonitor`/ffprobe now use only source args; the main FFmpeg uses effective inputs in `stream_to_youtube.py`.
  - Diagnostics show source input args, effective FFmpeg input args, and a sanitized full command; masks RTSP credentials.
  - Tests updated to ensure `anullsrc` appears only in effective args and that silent/source modes map streams correctly.

<sup>Written for commit 13be4e4ec77d4bc07188d813bcd05d73d0a22d45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/storesace-cv/bwb-stream2yt/pull/206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

