### PR TITLE
fix: resolve audio per source so failover is not blocked

### DIFF
--- a/primary-windows/src/stream_audio.py
+++ b/primary-windows/src/stream_audio.py
@@ -257,41 +257,133 @@ def probe_input_has_audio(
     return AudioProbeResult(ok=True, has_audio=False, error_kind="no_audio")
 
 
-def apply_audio_mode_to_config(config: Any, mode: Optional[str]) -> Any:
-    """Aplica modo de áudio a StreamingConfig (output/maps), sem alterar a fonte."""
+AUDIO_PROBE_MAX_TIMEOUT_S = 3.0
+AUDIO_FALLBACK_EVENT_MESSAGE = "Áudio não disponível; transmissão mantida sem som."
 
-    normalized = normalize_audio_mode(mode)
-    if normalized == AUDIO_MODE_SOURCE:
-        result = probe_input_has_audio(
-            getattr(getattr(config, "camera_probe", None), "ffprobe", "") or "",
-            list(config.input_args),
-            timeout=min(
-                3.0,
-                float(
-                    getattr(getattr(config, "camera_probe", None), "timeout", 7.0)
-                    or 7.0
-                ),
-            ),
-        )
-        if result.ok and not result.has_audio:
-            raise ValueError(NO_AUDIO_AVAILABLE_MESSAGE)
-        if not result.ok:
-            raise ValueError(AUDIO_PROBE_FAILED_MESSAGE)
-        output_args = build_audio_aware_output_args(config.output_args, silent=False)
-        return replace(
+
+@dataclass(frozen=True)
+class AudioResolution:
+    """Resultado da resolução de áudio por fonte (nunca bloqueia o vídeo)."""
+
+    config: Any
+    requested_audio_mode: str
+    effective_audio_mode: str
+    audio_detected: bool
+    probe: AudioProbeResult
+    used_silent_fallback: bool = False
+
+    @property
+    def audio_probe_error_kind(self) -> Optional[str]:
+        return self.probe.error_kind
+
+
+def _probe_timeout_for_config(
+    config: Any, *, deadline_remaining: Optional[float] = None
+) -> float:
+    configured = float(
+        getattr(getattr(config, "camera_probe", None), "timeout", 7.0) or 7.0
+    )
+    timeout = min(AUDIO_PROBE_MAX_TIMEOUT_S, configured)
+    if deadline_remaining is not None:
+        timeout = min(timeout, max(0.0, float(deadline_remaining)))
+    return timeout
+
+
+def resolve_audio_for_source(
+    config: Any,
+    requested_mode: Optional[str],
+    *,
+    timeout: Optional[float] = None,
+    deadline_remaining: Optional[float] = None,
+    run: Callable[..., Any] = subprocess.run,
+) -> AudioResolution:
+    """Resolve áudio efetivo para uma fonte prestes a iniciar.
+
+    - silent → anullsrc (sem probe)
+    - source + áudio confirmado → faixa original
+    - source + sem áudio / erro / timeout / prazo esgotado → silencioso
+    Nunca bloqueia o arranque do vídeo.
+    """
+
+    requested = normalize_audio_mode(requested_mode)
+
+    def _as_silent(probe: AudioProbeResult, *, used_fallback: bool) -> AudioResolution:
+        output_args = build_audio_aware_output_args(config.output_args, silent=True)
+        updated = replace(
             config,
             output_args=output_args,
-            audio_mode=normalized,
-            audio_detected=True,
+            audio_mode=AUDIO_MODE_SILENT,
+            audio_detected=False,
+            requested_audio_mode=requested,
+            audio_probe_error_kind=probe.error_kind,
+        )
+        return AudioResolution(
+            config=updated,
+            requested_audio_mode=requested,
+            effective_audio_mode=AUDIO_MODE_SILENT,
+            audio_detected=False,
+            probe=probe,
+            used_silent_fallback=used_fallback,
         )
 
-    output_args = build_audio_aware_output_args(config.output_args, silent=True)
-    return replace(
-        config,
-        output_args=output_args,
-        audio_mode=normalized,
-        audio_detected=False,
+    if requested == AUDIO_MODE_SILENT:
+        return _as_silent(
+            AudioProbeResult(ok=True, has_audio=False, error_kind=None),
+            used_fallback=False,
+        )
+
+    effective_timeout = AUDIO_PROBE_MAX_TIMEOUT_S if timeout is None else float(timeout)
+    effective_timeout = min(
+        effective_timeout,
+        _probe_timeout_for_config(config, deadline_remaining=deadline_remaining),
     )
+    if effective_timeout <= 0:
+        return _as_silent(
+            AudioProbeResult(
+                ok=False,
+                has_audio=False,
+                error_kind="timeout",
+                sanitized_detail="prazo de troca esgotado para probe de áudio",
+            ),
+            used_fallback=True,
+        )
+
+    probe = probe_input_has_audio(
+        getattr(getattr(config, "camera_probe", None), "ffprobe", "") or "",
+        list(config.input_args),
+        timeout=effective_timeout,
+        run=run,
+    )
+    if probe.ok and probe.has_audio:
+        output_args = build_audio_aware_output_args(config.output_args, silent=False)
+        updated = replace(
+            config,
+            output_args=output_args,
+            audio_mode=AUDIO_MODE_SOURCE,
+            audio_detected=True,
+            requested_audio_mode=requested,
+            audio_probe_error_kind=None,
+        )
+        return AudioResolution(
+            config=updated,
+            requested_audio_mode=requested,
+            effective_audio_mode=AUDIO_MODE_SOURCE,
+            audio_detected=True,
+            probe=probe,
+            used_silent_fallback=False,
+        )
+
+    return _as_silent(probe, used_fallback=True)
+
+
+def apply_audio_mode_to_config(config: Any, mode: Optional[str]) -> Any:
+    """Aplica modo de áudio a StreamingConfig (output/maps), sem alterar a fonte.
+
+    Com áudio: usa a faixa original quando disponível; caso contrário silencioso.
+    Nunca levanta ValueError por falha/ausência de áudio.
+    """
+
+    return resolve_audio_for_source(config, mode).config
 
 
 def build_effective_ffmpeg_input_args(config: Any) -> List[str]:

--- a/primary-windows/src/stream_to_youtube.py
+++ b/primary-windows/src/stream_to_youtube.py
@@ -58,12 +58,15 @@ from source_failover import (
     SourceFailoverController,
 )
 from stream_audio import (
-    AUDIO_PROBE_FAILED_MESSAGE,
-    NO_AUDIO_AVAILABLE_MESSAGE,
+    AUDIO_FALLBACK_EVENT_MESSAGE,
+    AUDIO_MODE_SILENT,
+    AUDIO_MODE_SOURCE,
+    AUDIO_PROBE_MAX_TIMEOUT_S,
     apply_audio_mode_to_config,
     audio_mode_label,
     build_effective_ffmpeg_input_args,
     normalize_audio_mode,
+    resolve_audio_for_source,
 )
 
 
@@ -1648,6 +1651,8 @@ class StreamingConfig:
     demo_mode: bool = False
     audio_mode: Optional[str] = None
     audio_detected: Optional[bool] = None
+    requested_audio_mode: Optional[str] = None
+    audio_probe_error_kind: Optional[str] = None
     camera_failover_to_demo: bool = False
     contingency_demo_path: Optional[str] = None
 
@@ -1742,9 +1747,23 @@ def prepare_ui_session_config(
             tz_offset_hours=tz_offset_hours,
         )
     if apply_audio and audio_mode is not None:
-        config = apply_audio_mode_to_config(config, audio_mode)
+        if bool(camera_failover_to_demo) and demo_video_path is None:
+            # Failover: guardar o pedido; resolver áudio só na fonte efetiva.
+            config = replace(
+                config,
+                requested_audio_mode=normalize_audio_mode(audio_mode),
+                audio_mode=None,
+                audio_detected=None,
+                audio_probe_error_kind=None,
+            )
+        else:
+            config = apply_audio_mode_to_config(config, audio_mode)
     elif audio_mode is not None:
-        config = replace(config, audio_mode=normalize_audio_mode(audio_mode))
+        config = replace(
+            config,
+            audio_mode=normalize_audio_mode(audio_mode),
+            requested_audio_mode=normalize_audio_mode(audio_mode),
+        )
     if camera_failover_to_demo is not None or contingency_demo_path is not None:
         config = replace(
             config,
@@ -2421,8 +2440,23 @@ class StreamingWorker:
         self._failover_last_launch_attempt: float = 0.0
 
         failover_enabled = bool(failover_enabled) and not config.demo_mode
+        requested_audio = normalize_audio_mode(
+            config.requested_audio_mode or config.audio_mode or AUDIO_MODE_SILENT
+        )
+        self._requested_audio_mode = requested_audio
+        self._last_audio_resolution = None
+        self._audio_fallback_logged = False
+
         if failover_enabled:
             base_camera_config = camera_config if camera_config is not None else config
+            # Templates por fonte sem áudio resolvido (probe só no arranque da fonte).
+            base_camera_config = replace(
+                base_camera_config,
+                requested_audio_mode=requested_audio,
+                audio_mode=None,
+                audio_detected=None,
+                audio_probe_error_kind=None,
+            )
             demo_path = resolve_demo_video_path(
                 explicit=contingency_demo_path
                 or base_camera_config.contingency_demo_path
@@ -2430,19 +2464,21 @@ class StreamingWorker:
             demo_config = contingency_demo_config
             if demo_config is None:
                 demo_config = apply_demo_video_source(base_camera_config, demo_path)
-                if base_camera_config.audio_mode is not None:
-                    try:
-                        demo_config = apply_audio_mode_to_config(
-                            demo_config, base_camera_config.audio_mode
-                        )
-                    except ValueError:
-                        # Contingência não deve falhar por ausência de áudio na fonte demo;
-                        # mantém o modo silencioso já aplicado por apply_demo_video_source.
-                        pass
+            demo_config = replace(
+                demo_config,
+                requested_audio_mode=requested_audio,
+                audio_mode=None,
+                audio_detected=None,
+                audio_probe_error_kind=None,
+            )
             self._camera_config = base_camera_config
             self._contingency_demo_config = demo_config
             self._failover_demo_path = demo_path
             config = base_camera_config
+        else:
+            self._camera_config = None
+            self._contingency_demo_config = None
+            self._failover_demo_path = None
 
         self._config = config
         self._thread: Optional[threading.Thread] = None
@@ -2485,6 +2521,17 @@ class StreamingWorker:
                 demo_exists=lambda: demo_video_exists(demo_path),
             )
             self._failover_controller.start_camera_session()
+        else:
+            self._failover_controller = None
+            # Sessão sem failover: resolver áudio da fonte já selecionada.
+            if config.audio_mode is None and (
+                config.requested_audio_mode is not None or requested_audio
+            ):
+                self._config = self._resolve_active_audio(config).config
+                self._base_output_args = list(self._config.output_args)
+                self._base_preset = _extract_arg_value(
+                    self._base_output_args, "-preset"
+                )
 
     def start(self) -> None:
         if self.is_running:
@@ -2588,7 +2635,66 @@ class StreamingWorker:
         else:
             snapshot["failover_enabled"] = False
 
+        audio_source = (
+            "contingency_demo"
+            if self._config.demo_mode
+            else (
+                "camera"
+                if not snapshot.get("effective_source")
+                else snapshot.get("effective_source")
+            )
+        )
+        if self._failover_controller is not None:
+            audio_source = snapshot.get("effective_source") or "camera"
+        resolution = self._last_audio_resolution
+        snapshot.update(
+            {
+                "requested_audio_mode": self._requested_audio_mode,
+                "effective_audio_mode": (
+                    resolution.effective_audio_mode
+                    if resolution is not None
+                    else self._config.audio_mode
+                ),
+                "audio_detected": (
+                    resolution.audio_detected
+                    if resolution is not None
+                    else self._config.audio_detected
+                ),
+                "audio_probe_error_kind": (
+                    resolution.audio_probe_error_kind
+                    if resolution is not None
+                    else self._config.audio_probe_error_kind
+                ),
+                "audio_source": audio_source,
+            }
+        )
+
         return snapshot
+
+    def _resolve_active_audio(
+        self,
+        config: StreamingConfig,
+        *,
+        deadline_mono: Optional[float] = None,
+    ):
+        remaining: Optional[float] = None
+        if deadline_mono is not None:
+            remaining = max(0.0, float(deadline_mono) - time.monotonic())
+        resolution = resolve_audio_for_source(
+            config,
+            self._requested_audio_mode,
+            timeout=AUDIO_PROBE_MAX_TIMEOUT_S,
+            deadline_remaining=remaining,
+        )
+        self._last_audio_resolution = resolution
+        if (
+            resolution.used_silent_fallback
+            and self._requested_audio_mode == AUDIO_MODE_SOURCE
+            and not self._audio_fallback_logged
+        ):
+            self._audio_fallback_logged = True
+            log_event("primary", AUDIO_FALLBACK_EVENT_MESSAGE)
+        return resolution
 
     def _run_loop(self) -> None:
         if self._failover_controller is not None:
@@ -3003,7 +3109,10 @@ class StreamingWorker:
                     )
                     self._apply_failover_action(follow_up, _depth + 1)
                 return
-            self._switch_active_config(target_config)
+            self._switch_active_config(
+                target_config,
+                deadline_mono=self._failover_controller.transition.deadline,
+            )
             launched = self._launch_ffmpeg()
             if launched and self._await_rtmps_sending(FIRST_PROGRESS_WAIT_S):
                 log_event("primary", "Vídeo de contingência a enviar com sucesso.")
@@ -3022,7 +3131,10 @@ class StreamingWorker:
             camera_config = self._camera_config
             if camera_config is None:
                 return
-            self._switch_active_config(camera_config)
+            self._switch_active_config(
+                camera_config,
+                deadline_mono=self._failover_controller.transition.deadline,
+            )
             launched = self._launch_ffmpeg()
             if launched and self._await_rtmps_sending(FIRST_PROGRESS_WAIT_S):
                 log_event("primary", "Câmara restabelecida e a enviar com sucesso.")
@@ -3050,7 +3162,10 @@ class StreamingWorker:
             self._terminate_process(timeout=FFMPEG_STOP_TIMEOUT_S)
             target_config = self._contingency_demo_config
             if target_config is not None:
-                self._switch_active_config(target_config)
+                self._switch_active_config(
+                    target_config,
+                    deadline_mono=self._failover_controller.transition.deadline,
+                )
                 self._launch_ffmpeg()
             return
 
@@ -3058,7 +3173,10 @@ class StreamingWorker:
             self._terminate_process(timeout=FFMPEG_STOP_TIMEOUT_S)
             camera_config = self._camera_config
             if camera_config is not None:
-                self._switch_active_config(camera_config)
+                self._switch_active_config(
+                    camera_config,
+                    deadline_mono=self._failover_controller.transition.deadline,
+                )
                 self._launch_ffmpeg()
             return
 
@@ -3068,13 +3186,22 @@ class StreamingWorker:
             self._terminate_process(timeout=FFMPEG_STOP_TIMEOUT_S)
             return
 
-    def _switch_active_config(self, new_config: StreamingConfig) -> None:
-        self._config = new_config
-        self._base_output_args = list(new_config.output_args)
+    def _switch_active_config(
+        self,
+        new_config: StreamingConfig,
+        *,
+        deadline_mono: Optional[float] = None,
+    ) -> None:
+        prepared = self._resolve_active_audio(
+            new_config, deadline_mono=deadline_mono
+        ).config
+        self._config = prepared
+        self._base_output_args = list(prepared.output_args)
         self._base_preset = _extract_arg_value(self._base_output_args, "-preset")
         self._last_autotune_bitrate = None
         self._last_autotune_preset = None
         self._autotune_failed_once = False
+        self._audio_fallback_logged = False
 
     def _ensure_process_for_config(
         self,
@@ -3090,7 +3217,7 @@ class StreamingWorker:
         if now - self._failover_last_launch_attempt < min_relaunch_gap:
             return
         self._failover_last_launch_attempt = now
-        if self._config is not config:
+        if self._config is not config or self._config.audio_mode is None:
             self._switch_active_config(config)
         self._launch_ffmpeg()
 
@@ -3472,19 +3599,31 @@ def _start_streaming_instance(
                         f"UTC{config.tz_offset_hours:+d}); sem alterar .env."
                     )
                 if audio_mode is not None:
-                    try:
-                        config = apply_audio_mode_to_config(config, audio_mode)
-                    except ValueError as exc:
-                        message = str(exc) or NO_AUDIO_AVAILABLE_MESSAGE
-                        logger.log(message)
-                        print(f"[primary] {message}", file=sys.stderr)
-                        log_event("primary", message)
-                        if message == AUDIO_PROBE_FAILED_MESSAGE:
-                            return 5
-                        return 4
-                    logger.log(
-                        f"Modo de áudio da sessão: {audio_mode_label(config.audio_mode)}."
-                    )
+                    requested = normalize_audio_mode(audio_mode)
+                    if camera_failover_to_demo and demo_video_path is None:
+                        # Fonte efetiva ainda não conhecida: não sondar a câmara.
+                        config = replace(
+                            config,
+                            requested_audio_mode=requested,
+                            audio_mode=None,
+                            audio_detected=None,
+                            audio_probe_error_kind=None,
+                        )
+                        logger.log(
+                            "Modo de áudio pedido: "
+                            f"{audio_mode_label(requested)} "
+                            "(resolução adiada até à fonte efetiva)."
+                        )
+                    else:
+                        resolution = resolve_audio_for_source(config, requested)
+                        config = resolution.config
+                        logger.log(
+                            "Modo de áudio da sessão: "
+                            f"{audio_mode_label(resolution.requested_audio_mode)} "
+                            f"(efetivo: {audio_mode_label(resolution.effective_audio_mode)})."
+                        )
+                        if resolution.used_silent_fallback:
+                            logger.log(AUDIO_FALLBACK_EVENT_MESSAGE)
                 logger.log(
                     f"Configuração carregada; resolução reportada: {config.resolution}."
                 )

--- a/primary-windows/src/ui_app.py
+++ b/primary-windows/src/ui_app.py
@@ -46,8 +46,6 @@ from ui_settings import (
 from stream_audio import (
     AUDIO_MODE_SILENT,
     AUDIO_MODE_SOURCE,
-    AUDIO_PROBE_FAILED_MESSAGE,
-    NO_AUDIO_AVAILABLE_MESSAGE,
     audio_mode_label,
 )
 from send_quality import (
@@ -961,10 +959,6 @@ def run_ui_app(*, resolution: Optional[str] = None) -> int:
                     "message",
                     demo_video_missing_message(demo_path or settings.demo_video_path),
                 )
-            elif code == 4:
-                self._post("message", NO_AUDIO_AVAILABLE_MESSAGE)
-            elif code == 5:
-                self._post("message", AUDIO_PROBE_FAILED_MESSAGE)
             elif code != 0:
                 self._post("message", f"Arranque terminou com código {code}.")
             else:

--- a/tests/test_audio_probe_failover_args.py
+++ b/tests/test_audio_probe_failover_args.py
@@ -15,10 +15,10 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 from stream_audio import (  # noqa: E402
+    AUDIO_MODE_SILENT,
     AUDIO_MODE_SOURCE,
-    AUDIO_PROBE_FAILED_MESSAGE,
-    NO_AUDIO_AVAILABLE_MESSAGE,
     apply_audio_mode_to_config,
+    build_effective_ffmpeg_input_args,
     build_ffprobe_input_args,
     probe_input_has_audio,
 )
@@ -29,6 +29,10 @@ class _Config:
     input_args: list[str]
     output_args: list[str]
     camera_probe: object
+    audio_mode: object = None
+    audio_detected: object = None
+    requested_audio_mode: object = None
+    audio_probe_error_kind: object = None
 
 
 def test_ffprobe_args_remove_ffmpeg_flags_and_lavfi() -> None:
@@ -51,7 +55,7 @@ def test_probe_detects_aac_audio() -> None:
     assert result.ok and result.has_audio and result.error_kind is None
 
 
-def test_probe_no_audio_and_apply_raises(monkeypatch) -> None:
+def test_probe_no_audio_falls_back_silent(monkeypatch) -> None:
     result = probe_input_has_audio(
         "ffprobe",
         ["-i", "demo.mp4"],
@@ -64,8 +68,9 @@ def test_probe_no_audio_and_apply_raises(monkeypatch) -> None:
         ["-i", "demo.mp4"], [], SimpleNamespace(ffprobe="ffprobe", timeout=2.0)
     )
     monkeypatch.setattr("stream_audio.probe_input_has_audio", lambda *_a, **_kw: result)
-    with pytest.raises(ValueError, match=NO_AUDIO_AVAILABLE_MESSAGE):
-        apply_audio_mode_to_config(config, AUDIO_MODE_SOURCE)
+    updated = apply_audio_mode_to_config(config, AUDIO_MODE_SOURCE)
+    assert updated.audio_mode == AUDIO_MODE_SILENT
+    assert "anullsrc=" in " ".join(build_effective_ffmpeg_input_args(updated))
 
 
 @pytest.mark.parametrize(
@@ -79,15 +84,16 @@ def test_probe_no_audio_and_apply_raises(monkeypatch) -> None:
         ),
     ],
 )
-def test_probe_failure_is_not_no_audio(monkeypatch, run) -> None:
+def test_probe_failure_falls_back_silent(monkeypatch, run) -> None:
     result = probe_input_has_audio("ffprobe", ["-i", "rtsp://cam/stream"], run=run)
     assert not result.ok and result.error_kind != "no_audio"
     config = _Config(
         ["-i", "rtsp://cam/stream"], [], SimpleNamespace(ffprobe="ffprobe", timeout=2.0)
     )
     monkeypatch.setattr("stream_audio.probe_input_has_audio", lambda *_a, **_kw: result)
-    with pytest.raises(ValueError, match=AUDIO_PROBE_FAILED_MESSAGE):
-        apply_audio_mode_to_config(config, AUDIO_MODE_SOURCE)
+    updated = apply_audio_mode_to_config(config, AUDIO_MODE_SOURCE)
+    assert updated.audio_mode == AUDIO_MODE_SILENT
+    assert "anullsrc=" in " ".join(build_effective_ffmpeg_input_args(updated))
 
 
 def test_probe_error_masks_rtsp_password() -> None:

--- a/tests/test_failover_audio_resolve.py
+++ b/tests/test_failover_audio_resolve.py
@@ -1,0 +1,338 @@
+"""Áudio por fonte no failover: nunca bloqueia o arranque."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import types
+from dataclasses import replace
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SRC = ROOT / "primary-windows" / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from stream_audio import (  # noqa: E402
+    AUDIO_MODE_SILENT,
+    AUDIO_MODE_SOURCE,
+    AUDIO_PROBE_MAX_TIMEOUT_S,
+    AudioProbeResult,
+    apply_audio_mode_to_config,
+    build_effective_ffmpeg_input_args,
+    resolve_audio_for_source,
+)
+
+
+def _load_stream_module():
+    path = SRC / "stream_to_youtube.py"
+    name = "_stream_failover_audio_resolve_test"
+    if name in sys.modules:
+        return sys.modules[name]
+    if "autotune" not in sys.modules:
+        stub = types.ModuleType("autotune")
+        stub.estimate_upload_bitrate = lambda *_a, **_k: (_ for _ in ()).throw(  # type: ignore
+            NotImplementedError
+        )
+        stub.AUTOTUNE_AVAILABLE = False  # type: ignore[attr-defined]
+        stub.AUTOTUNE_UNAVAILABLE_REASON = ""  # type: ignore[attr-defined]
+        sys.modules["autotune"] = stub
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+module = _load_stream_module()
+
+
+def _base_config(**overrides):
+    cfg = module.StreamingConfig(
+        yt_url="rtmps://a.rtmps.youtube.com/live2/EXEMPLO",
+        input_args=["-rtsp_transport", "tcp", "-i", "rtsp://cam/stream"],
+        output_args=["-c:v", "libx264", "-c:a", "aac", "-b:a", "64k"],
+        resolution="1080p",
+        ffmpeg="ffmpeg",
+        day_start_hour=0,
+        day_end_hour=24,
+        tz_offset_hours=0,
+        autotune_enabled=False,
+        bitrate_min_kbps=1000,
+        bitrate_max_kbps=5000,
+        autotune_interval=8.0,
+        autotune_safety_margin=0.5,
+        heartbeat=module.HeartbeatConfig(
+            enabled=False,
+            endpoint=None,
+            interval=20.0,
+            timeout=5.0,
+            machine_id="TEST",
+            token=None,
+            log_path=Path("/tmp/hb.jsonl"),
+            log_retention_seconds=3600,
+        ),
+        camera_probe=module.CameraProbeConfig(
+            ffprobe="ffprobe", interval=5.0, timeout=7.0, required=False
+        ),
+    )
+    if overrides:
+        cfg = replace(cfg, **overrides)
+    return cfg
+
+
+def test_resolve_silent_skips_probe(monkeypatch):
+    called = {"n": 0}
+
+    def boom(*_a, **_k):
+        called["n"] += 1
+        raise AssertionError("probe não deve correr em silent")
+
+    monkeypatch.setattr("stream_audio.probe_input_has_audio", boom)
+    resolution = resolve_audio_for_source(_base_config(), AUDIO_MODE_SILENT)
+    assert called["n"] == 0
+    assert resolution.effective_audio_mode == AUDIO_MODE_SILENT
+    assert "anullsrc=" in " ".join(build_effective_ffmpeg_input_args(resolution.config))
+
+
+def test_resolve_source_with_audio_keeps_original(monkeypatch):
+    monkeypatch.setattr(
+        "stream_audio.probe_input_has_audio",
+        lambda *a, **k: AudioProbeResult(ok=True, has_audio=True),
+    )
+    resolution = resolve_audio_for_source(_base_config(), AUDIO_MODE_SOURCE)
+    assert resolution.effective_audio_mode == AUDIO_MODE_SOURCE
+    assert resolution.audio_detected is True
+    assert resolution.config.output_args[:4] == ["-map", "0:v:0", "-map", "0:a:0"]
+    assert "anullsrc=" not in " ".join(
+        build_effective_ffmpeg_input_args(resolution.config)
+    )
+
+
+def test_resolve_source_without_audio_or_error_falls_back_silent(monkeypatch):
+    for probe in (
+        AudioProbeResult(ok=True, has_audio=False, error_kind="no_audio"),
+        AudioProbeResult(ok=False, has_audio=False, error_kind="timeout"),
+        AudioProbeResult(ok=False, has_audio=False, error_kind="connect_failed"),
+    ):
+
+        def _probe(*_a, _p=probe, **_k):
+            return _p
+
+        monkeypatch.setattr("stream_audio.probe_input_has_audio", _probe)
+        resolution = resolve_audio_for_source(_base_config(), AUDIO_MODE_SOURCE)
+        assert resolution.effective_audio_mode == AUDIO_MODE_SILENT
+        assert resolution.used_silent_fallback is True
+        assert "anullsrc=" in " ".join(
+            build_effective_ffmpeg_input_args(resolution.config)
+        )
+
+
+def test_resolve_respects_exhausted_deadline(monkeypatch):
+    called = {"n": 0}
+
+    def boom(*_a, **_k):
+        called["n"] += 1
+        raise AssertionError("sem tempo → sem probe")
+
+    monkeypatch.setattr("stream_audio.probe_input_has_audio", boom)
+    resolution = resolve_audio_for_source(
+        _base_config(), AUDIO_MODE_SOURCE, deadline_remaining=0.0
+    )
+    assert called["n"] == 0
+    assert resolution.effective_audio_mode == AUDIO_MODE_SILENT
+    assert resolution.probe.error_kind == "timeout"
+    assert resolution.used_silent_fallback is True
+
+
+def test_apply_audio_mode_no_longer_raises(monkeypatch):
+    monkeypatch.setattr(
+        "stream_audio.probe_input_has_audio",
+        lambda *a, **k: AudioProbeResult(
+            ok=True, has_audio=False, error_kind="no_audio"
+        ),
+    )
+    updated = apply_audio_mode_to_config(_base_config(), AUDIO_MODE_SOURCE)
+    assert updated.audio_mode == AUDIO_MODE_SILENT
+
+
+def test_failover_startup_does_not_probe_camera(monkeypatch, tmp_path):
+    demo = tmp_path / "demo.mp4"
+    demo.write_bytes(b"fake")
+    probed = {"n": 0}
+
+    def counting_probe(*_a, **_k):
+        probed["n"] += 1
+        return AudioProbeResult(ok=False, has_audio=False, error_kind="connect_failed")
+
+    monkeypatch.setattr("stream_audio.probe_input_has_audio", counting_probe)
+    monkeypatch.setattr(module, "demo_video_exists", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        module, "resolve_demo_video_path", lambda explicit=None, **_k: str(demo)
+    )
+
+    config = _base_config(
+        camera_failover_to_demo=True,
+        contingency_demo_path=str(demo),
+        requested_audio_mode=AUDIO_MODE_SOURCE,
+        audio_mode=None,
+    )
+    worker = module.StreamingWorker(
+        config, failover_enabled=True, contingency_demo_path=str(demo)
+    )
+    assert probed["n"] == 0
+    assert worker._camera_config is not None
+    assert worker._camera_config.audio_mode is None
+    assert worker._contingency_demo_config is not None
+    assert worker._contingency_demo_config.demo_mode is True
+    assert worker._contingency_demo_config.audio_mode is None
+    assert worker._requested_audio_mode == AUDIO_MODE_SOURCE
+
+
+def test_switch_to_demo_resolves_audio_from_mp4(monkeypatch, tmp_path):
+    demo = tmp_path / "demo-praia.mp4"
+    demo.write_bytes(b"fake")
+    monkeypatch.setattr(module, "demo_video_exists", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        module, "resolve_demo_video_path", lambda explicit=None, **_k: str(demo)
+    )
+    monkeypatch.setattr(
+        "stream_audio.probe_input_has_audio",
+        lambda *a, **k: AudioProbeResult(ok=True, has_audio=True),
+    )
+    config = _base_config(
+        camera_failover_to_demo=True,
+        contingency_demo_path=str(demo),
+        requested_audio_mode=AUDIO_MODE_SOURCE,
+        audio_mode=None,
+    )
+    worker = module.StreamingWorker(
+        config, failover_enabled=True, contingency_demo_path=str(demo)
+    )
+    assert worker._contingency_demo_config is not None
+    prepared = worker._resolve_active_audio(worker._contingency_demo_config)
+    assert prepared.effective_audio_mode == AUDIO_MODE_SOURCE
+    assert prepared.audio_detected is True
+
+
+def test_switch_to_demo_without_audio_uses_silent(monkeypatch, tmp_path):
+    demo = tmp_path / "demo.mp4"
+    demo.write_bytes(b"fake")
+    monkeypatch.setattr(module, "demo_video_exists", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        module, "resolve_demo_video_path", lambda explicit=None, **_k: str(demo)
+    )
+    monkeypatch.setattr(
+        "stream_audio.probe_input_has_audio",
+        lambda *a, **k: AudioProbeResult(
+            ok=True, has_audio=False, error_kind="no_audio"
+        ),
+    )
+    worker = module.StreamingWorker(
+        _base_config(
+            camera_failover_to_demo=True,
+            contingency_demo_path=str(demo),
+            requested_audio_mode=AUDIO_MODE_SOURCE,
+            audio_mode=None,
+        ),
+        failover_enabled=True,
+        contingency_demo_path=str(demo),
+    )
+    prepared = worker._resolve_active_audio(worker._contingency_demo_config)
+    assert prepared.effective_audio_mode == AUDIO_MODE_SILENT
+    assert "anullsrc=" in " ".join(build_effective_ffmpeg_input_args(prepared.config))
+
+
+def test_camera_recovery_audio_paths(monkeypatch, tmp_path):
+    demo = tmp_path / "demo.mp4"
+    demo.write_bytes(b"fake")
+    monkeypatch.setattr(module, "demo_video_exists", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        module, "resolve_demo_video_path", lambda explicit=None, **_k: str(demo)
+    )
+    worker = module.StreamingWorker(
+        _base_config(
+            camera_failover_to_demo=True,
+            contingency_demo_path=str(demo),
+            requested_audio_mode=AUDIO_MODE_SOURCE,
+            audio_mode=None,
+        ),
+        failover_enabled=True,
+        contingency_demo_path=str(demo),
+    )
+
+    monkeypatch.setattr(
+        "stream_audio.probe_input_has_audio",
+        lambda *a, **k: AudioProbeResult(ok=True, has_audio=True),
+    )
+    with_audio = worker._resolve_active_audio(worker._camera_config)
+    assert with_audio.effective_audio_mode == AUDIO_MODE_SOURCE
+
+    monkeypatch.setattr(
+        "stream_audio.probe_input_has_audio",
+        lambda *a, **k: AudioProbeResult(
+            ok=True, has_audio=False, error_kind="no_audio"
+        ),
+    )
+    without = worker._resolve_active_audio(worker._camera_config)
+    assert without.effective_audio_mode == AUDIO_MODE_SILENT
+
+    monkeypatch.setattr(
+        "stream_audio.probe_input_has_audio",
+        lambda *a, **k: AudioProbeResult(
+            ok=False, has_audio=False, error_kind="timeout"
+        ),
+    )
+    failed = worker._resolve_active_audio(worker._camera_config)
+    assert failed.effective_audio_mode == AUDIO_MODE_SILENT
+
+
+def test_direct_demo_still_gets_aac(monkeypatch):
+    monkeypatch.setattr(
+        "stream_audio.probe_input_has_audio",
+        lambda *a, **k: AudioProbeResult(ok=True, has_audio=True),
+    )
+    demo_cfg = _base_config(
+        input_args=["-stream_loop", "-1", "-re", "-i", "/tmp/demo-praia-surfistas.mp4"],
+        demo_mode=True,
+    )
+    resolution = resolve_audio_for_source(demo_cfg, AUDIO_MODE_SOURCE)
+    assert resolution.effective_audio_mode == AUDIO_MODE_SOURCE
+    assert resolution.audio_detected is True
+
+
+def test_audio_probe_timeout_budget_constant():
+    assert AUDIO_PROBE_MAX_TIMEOUT_S == 3.0
+    assert AUDIO_PROBE_MAX_TIMEOUT_S <= 32.0
+
+
+def test_failover_audio_never_writes_env(monkeypatch, tmp_path):
+    env_path = tmp_path / ".env"
+    env_path.write_text("YT_URL=rtmps://example/live2/x\n", encoding="utf-8")
+    before = env_path.read_text(encoding="utf-8")
+    monkeypatch.setenv("YT_DAY_START_HOUR", "8")
+    demo = tmp_path / "demo.mp4"
+    demo.write_bytes(b"x")
+    monkeypatch.setattr(module, "demo_video_exists", lambda *_a, **_k: True)
+    monkeypatch.setattr(
+        module, "resolve_demo_video_path", lambda explicit=None, **_k: str(demo)
+    )
+    monkeypatch.setattr(
+        "stream_audio.probe_input_has_audio",
+        lambda *a, **k: AudioProbeResult(ok=True, has_audio=True),
+    )
+    worker = module.StreamingWorker(
+        _base_config(
+            camera_failover_to_demo=True,
+            contingency_demo_path=str(demo),
+            requested_audio_mode=AUDIO_MODE_SOURCE,
+            audio_mode=None,
+        ),
+        failover_enabled=True,
+        contingency_demo_path=str(demo),
+    )
+    worker._resolve_active_audio(worker._contingency_demo_config)
+    assert env_path.read_text(encoding="utf-8") == before
+    assert os.environ["YT_DAY_START_HOUR"] == "8"

--- a/tests/test_ui_settings_audio.py
+++ b/tests/test_ui_settings_audio.py
@@ -9,8 +9,6 @@ import types
 from dataclasses import replace
 from pathlib import Path
 
-import pytest
-
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "primary-windows" / "src"
 if str(SRC) not in sys.path:
@@ -22,7 +20,6 @@ from stream_audio import (  # noqa: E402
     AUDIO_MODE_SILENT,
     AUDIO_MODE_SOURCE,
     AudioProbeResult,
-    NO_AUDIO_AVAILABLE_MESSAGE,
     apply_audio_mode_to_config,
     build_audio_map_args,
     build_effective_ffmpeg_input_args,
@@ -285,15 +282,17 @@ def test_source_audio_uses_original_track(monkeypatch):
     assert updated.audio_detected is True
 
 
-def test_source_audio_without_track_raises(monkeypatch):
+def test_source_audio_without_track_falls_back_silent(monkeypatch):
     monkeypatch.setattr(
         "stream_audio.probe_input_has_audio",
         lambda *a, **k: AudioProbeResult(
             ok=True, has_audio=False, error_kind="no_audio"
         ),
     )
-    with pytest.raises(ValueError, match=NO_AUDIO_AVAILABLE_MESSAGE):
-        apply_audio_mode_to_config(_base_config(), AUDIO_MODE_SOURCE)
+    updated = apply_audio_mode_to_config(_base_config(), AUDIO_MODE_SOURCE)
+    assert updated.audio_mode == AUDIO_MODE_SILENT
+    assert updated.audio_detected is False
+    assert "anullsrc=" in " ".join(build_effective_ffmpeg_input_args(updated))
 
 
 def test_camera_video_only_works_with_silent():


### PR DESCRIPTION
## Summary
- Com failover ativo + Com áudio, deixa de analisar a câmara no arranque (o probe falhava e impedia a contingência).
- Áudio é resolvido por fonte (`resolve_audio_for_source`) só quando essa fonte vai iniciar.
- Com áudio: original se disponível; caso contrário silencioso — nunca bloqueia vídeo/failover.

## Test plan
- [x] pytest / black / flake8 / git diff --check
- [ ] CI verde
- [ ] Windows: câmara off + failover + Com áudio → demo com AAC; regresso à câmara


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolve audio per source at switch time to prevent failover from being blocked by startup probes. If audio is missing or probing fails, we fall back to silent AAC so video always starts.

- **Bug Fixes**
  - Skip camera audio probe at startup when failover is enabled; resolve audio only when the camera or demo source becomes active.
  - On no-audio, probe error, or timeout, use silent AAC (`anullsrc`) and never block video/failover; log a single fallback message.
  - Failover transitions resolve audio with a 3s cap or remaining deadline to avoid delaying source switches.

- **Refactors**
  - Added `resolve_audio_for_source(...)` and `AUDIO_PROBE_MAX_TIMEOUT_S`; `apply_audio_mode_to_config` now returns silent mode instead of raising.
  - Store `requested_audio_mode` and `audio_probe_error_kind`; status snapshot reports requested/effective mode, detection, and audio source.
  - Removed UI error paths for audio probe/no-audio codes; updated tests and added failover audio resolution tests.

<sup>Written for commit bbbc5bc39a8bf64626be8b97d56d9d3f2e4e566f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/storesace-cv/bwb-stream2yt/pull/208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

